### PR TITLE
Fixed bug with PR counts

### DIFF
--- a/app/models/hubstats/repo.rb
+++ b/app/models/hubstats/repo.rb
@@ -22,7 +22,7 @@ module Hubstats
     scope :pull_requests_count, lambda {|time|
       select("hubstats_repos.id as repo_id")
       .select("IFNULL(COUNT(DISTINCT hubstats_pull_requests.id),0) AS pull_request_count")
-      .joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.repo_id = hubstats_repos.id AND hubstats_pull_requests.created_at > '#{time}' AND hubstats_pull_requests.merged = '1'")
+      .joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.repo_id = hubstats_repos.id AND hubstats_pull_requests.merged_at > '#{time}' AND hubstats_pull_requests.merged = '1'")
       .group("hubstats_repos.id")
     }
 

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -21,7 +21,7 @@ module Hubstats
     scope :pull_requests_count, lambda {|time|
       select("hubstats_users.id as user_id")
       .select("IFNULL(COUNT(DISTINCT hubstats_pull_requests.id),0) AS pull_request_count")
-      .joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.user_id = hubstats_users.id AND hubstats_pull_requests.created_at > '#{time}' AND hubstats_pull_requests.merged = '1'")
+      .joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.user_id = hubstats_users.id AND hubstats_pull_requests.merged_at > '#{time}' AND hubstats_pull_requests.merged = '1'")
       .group("hubstats_users.id")
     }
 


### PR DESCRIPTION
Description and Impact
----------------------
This will fix a bug on the users, metrics, and repos pages that is counting only PRs that have been merged and created during the time frame, instead of just merged within the time frame (we don't care when they were created).

Deploy Plan
-----------
no new migrations

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below. Review [QA Best Practices](https://source.sportngin.com/page/show/1227795-qa-best-practices).

#### Happy Path Scenarios
- [ ] Example Happy Path scenario

#### Additional Scenarios (Edge Case, Negative, etc.)
- [ ] Example Edge Case scenario

#### Regression Scenarios
- [ ] Example Regression item on related feature
