### PR TITLE
Fixing date to not go by midnight, but current time

### DIFF
--- a/app/controllers/hubstats/application_controller.rb
+++ b/app/controllers/hubstats/application_controller.rb
@@ -7,7 +7,7 @@ module Hubstats
     def set_time
       cookies[:hubstats_index] ||= 2
       @start_date = DATE_RANGE_ARRAY[cookies[:hubstats_index].to_i][:date].ago.to_date
-      @end_date = Date.today
+      @end_date = Time.now
     end
   end
 end

--- a/app/views/hubstats/partials/_header.html.erb
+++ b/app/views/hubstats/partials/_header.html.erb
@@ -30,8 +30,6 @@
             </select>
           </li>
         </ul>
-        <!-- Start time: <%=@start_date%>
-        End time: <%=@end_date%> -->
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Description and Impact
----------------------
Fixing date to go by midnight so recent PRs, deploys, and changes will show up on Hubstats.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below. Review [QA Best Practices](https://source.sportngin.com/page/show/1227795-qa-best-practices).

#### Happy Path Scenarios
- [ ] Example Happy Path scenario

#### Additional Scenarios (Edge Case, Negative, etc.)
- [ ] Example Edge Case scenario

#### Regression Scenarios
- [ ] Example Regression item on related feature
