### PR TITLE
Fixing bugs that made counts different in show pages and indices

### DIFF
--- a/app/models/hubstats/repo.rb
+++ b/app/models/hubstats/repo.rb
@@ -54,7 +54,7 @@ module Hubstats
       select("hubstats_repos.id as repo_id")
       .select("ROUND(IFNULL(AVG(hubstats_pull_requests.additions),0)) AS average_additions")
       .select("ROUND(IFNULL(AVG(hubstats_pull_requests.deletions),0)) AS average_deletions")
-      .joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.repo_id = hubstats_repos.id AND hubstats_pull_requests.merged = '1' AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?)", start_date, end_date)
+      .joins(sanitize_sql_array(["LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.repo_id = hubstats_repos.id AND hubstats_pull_requests.merged = '1' AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?)", start_date, end_date]))
       .group("hubstats_repos.id")
     }
 
@@ -66,7 +66,7 @@ module Hubstats
     # Returns - all of the stats about the repo
     scope :with_all_metrics, lambda {|start_date, end_date|
       select("hubstats_repos.*, deploy_count, pull_request_count, comment_count, average_additions, average_deletions")
-      .joins("LEFT JOIN (#{averages.to_sql}) AS averages ON averages.repo_id = hubstats_repos.id")
+      .joins("LEFT JOIN (#{averages(start_date, end_date).to_sql}) AS averages ON averages.repo_id = hubstats_repos.id")
       .joins("LEFT JOIN (#{pull_requests_count(start_date, end_date).to_sql}) AS pull_requests ON pull_requests.repo_id = hubstats_repos.id")
       .joins("LEFT JOIN (#{comments_count(start_date, end_date).to_sql}) AS comments ON comments.repo_id = hubstats_repos.id")
       .joins("LEFT JOIN (#{deploys_count(start_date, end_date).to_sql}) AS deploys ON deploys.repo_id = hubstats_repos.id")

--- a/app/models/hubstats/repo.rb
+++ b/app/models/hubstats/repo.rb
@@ -50,11 +50,11 @@ module Hubstats
     # end_date - the end of the data range
     # 
     # Returns - the average additions and deletions
-    scope :averages, lambda {
+    scope :averages, lambda {|start_date, end_date|
       select("hubstats_repos.id as repo_id")
       .select("ROUND(IFNULL(AVG(hubstats_pull_requests.additions),0)) AS average_additions")
       .select("ROUND(IFNULL(AVG(hubstats_pull_requests.deletions),0)) AS average_deletions")
-      .joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.repo_id = hubstats_repos.id AND hubstats_pull_requests.merged = '1'")
+      .joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.repo_id = hubstats_repos.id AND hubstats_pull_requests.merged = '1' AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?)", start_date, end_date)
       .group("hubstats_repos.id")
     }
 

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -124,7 +124,7 @@ module Hubstats
       select("hubstats_users.id as user_id")
       .select("SUM(IFNULL(hubstats_pull_requests.additions, 0)) AS additions")
       .select("SUM(IFNULL(hubstats_pull_requests.deletions, 0)) AS deletions")
-      .joins(sanitize_sql_array(["LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.user_id = hubstats_users.id AND (hubstats_pull_requests.created_at BETWEEN ? AND ?) AND hubstats_pull_requests.merged = '1'", start_date, end_date]))
+      .joins(sanitize_sql_array(["LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.user_id = hubstats_users.id AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?) AND hubstats_pull_requests.merged = '1'", start_date, end_date]))
       .group("hubstats_users.id")
     }
 


### PR DESCRIPTION
Description and Impact
----------------------
Fixing a bug that counted additions and deletions on both the metrics page and the user page.

Deploy Plan
-----------
No new migrations with this PR.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
Run Hubstats and make sure that all of the counts are consistent.
