### PR TITLE
Adding teams and team commands, team sorting, and team metrics to Hubstats

### DIFF
--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -78,10 +78,8 @@ module Hubstats
     #
     # Returns - nothing
     def self.update_teams_in_pulls(days)
-      puts "Gathering pulls from past year"
       pulls = created_since(days)
       pulls.each {|pull| pull.assign_team_from_user}
-      puts "Finished updating teams for pull requests"
     end
 
     # Public - Filters all of the pull requests between start_date and end_date that are the given state

--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -52,6 +52,15 @@ module Hubstats
     #
     # Returns - an array of github repo objects
     def self.get_repos
+      if Hubstats.config.github_config.has_key?("org_name") == false
+        begin
+          raise RuntimeError, "!!! Could not finish rake task! Organization name in .octokit.yml is required, but was not found."
+        rescue Exception => e
+          puts e.message
+          exit 1
+        end
+      end
+
       if Hubstats.config.github_config.has_key?("repo_list")
         repos = []
         Hubstats.config.github_config["repo_list"].each do |repo|

--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -53,12 +53,8 @@ module Hubstats
     # Returns - an array of github repo objects
     def self.get_repos
       if Hubstats.config.github_config.has_key?("org_name") == false
-        begin
-          raise RuntimeError, "COULD NOT COMPLETE RAKE TASK! Organization name in .octokit.yml is required, but was not found."
-        rescue Exception => e
-          puts e.message
-          exit 1
-        end
+        raise RuntimeError, "COULD NOT COMPLETE RAKE TASK! Organization name in .octokit.yml is required, but was not found."
+        exit 1
       end
 
       if Hubstats.config.github_config.has_key?("repo_list")

--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -54,7 +54,6 @@ module Hubstats
     def self.get_repos
       if Hubstats.config.github_config.has_key?("org_name") == false
         raise RuntimeError, "COULD NOT COMPLETE RAKE TASK! Organization name in .octokit.yml is required, but was not found."
-        exit 1
       end
 
       if Hubstats.config.github_config.has_key?("repo_list")

--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -54,7 +54,7 @@ module Hubstats
     def self.get_repos
       if Hubstats.config.github_config.has_key?("org_name") == false
         begin
-          raise RuntimeError, "!!! Could not finish rake task! Organization name in .octokit.yml is required, but was not found."
+          raise RuntimeError, "COULD NOT COMPLETE RAKE TASK! Organization name in .octokit.yml is required, but was not found."
         rescue Exception => e
           puts e.message
           exit 1

--- a/lib/tasks/populate_task.rake
+++ b/lib/tasks/populate_task.rake
@@ -108,9 +108,9 @@ namespace :hubstats do
       Hubstats::GithubAPI.update_teams
     end
 
-    desc "updates the teams for all pull requests from past year"
+    desc "updates the teams for all pull requests from past 365 days"
     task :update_teams_in_prs => :environment do
-      Hubstats::PullRequest.update_teams_in_pulls
+      Hubstats::PullRequest.update_teams_in_pulls(365)
     end
 
     desc "Updates WebHooks for all repos"

--- a/spec/lib/hubstats/github_api_spec.rb
+++ b/spec/lib/hubstats/github_api_spec.rb
@@ -130,12 +130,12 @@ module Hubstats
         allow(subject).to receive(:client) {client}
       end
 
-      it "should call octokit create_hook" do
+      it "should call octokit create_hook for repositories" do
         expect(client).to receive(:create_hook)
         subject.create_hook(repo)
       end
 
-      it "should rescue unprocessable entity" do
+      it "should rescue unprocessable entity from repo hook" do
         allow(client).to receive(:create_hook) { raise Octokit::UnprocessableEntity }
         subject.create_hook(repo)
       end
@@ -151,12 +151,12 @@ module Hubstats
         allow(subject).to receive(:client) {client}
       end
 
-      it "should call octokit create_hook" do
+      it "should call octokit create_hook for organizations" do
         expect(client).to receive(:create_hook)
         subject.create_hook(org)
       end
 
-      it "should rescue unprocessable entity" do
+      it "should rescue unprocessable entity from organization hook" do
         allow(client).to receive(:create_hook) { raise Octokit::UnprocessableEntity }
         subject.create_hook(org)
       end

--- a/spec/models/hubstats/pull_request_spec.rb
+++ b/spec/models/hubstats/pull_request_spec.rb
@@ -71,7 +71,7 @@ module Hubstats
       team.users << user2
       pull1 = build(:pull_request, :created_at => Date.today - 250, :user => user1)
       pull2 = build(:pull_request, :created_at => Date.today - 3, :repo => repo, :user => user2)
-      Hubstats::PullRequest.update_teams_in_pulls
+      Hubstats::PullRequest.update_teams_in_pulls(365)
       expect(pull1.team_id).to eq(team.id)
       expect(pull2.team_id).to eq(team.id)
     end


### PR DESCRIPTION
Description and Impact
----------------------
* This will make it so that Hubstats will receive info about teams that come from Github Webhooks. 
 * It associates users with teams. 
 * When a pull request is updated or created from there on out, it will look to see if the user who makes the PR has a team, and then if it does, will update a value in the PR's data as well to reflect the team.
* There is a filter on the PR page so that the PRs can be filtered by team as well as by users and repos. 
* This PR also has a team index page which will show stats (users, PRs, comments, repos, net additions) for each team.
* There is a team show page where more detailed stats, as well as a list of all of the users and PRs associated with that team can be seen.
* There are two new commands that can be run which will:
 * grab all of the teams from github that this user is a member of (by "this user", I mean the owner of the access_token in the `octokit.yml`), make each team if it is on the list on the `octokit.yml`, and update all of the users in each team.
 * grab all of the pull requests from the past year, and if the user of each PR is part of a team, update the team_id of the PR.
* There are also more tests that will test the team functionality.
* Major edits on the README to reflect new changes in the code and to improve clarity.

Deploy Plan
-----------
* There are three more migrations (team table, team/user table, adding column to PR table) that must be run.
* Depends on https://github.com/sportngin/opsworks-app-cookbooks/pull/401

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
* Test that the webhooks are working correctly
* Make sure that new team functionality is working on both index page and show page
* Check out the filtering of PRs by team names
* Check that the new rake commands (`rake hubstats:update_teams` and `rake hubstats:update_teams_in_pulls`) are working correctly
