### PR TITLE
Making the team's user column to be developers/reviewers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 gem "mysql2"
+gem "bootstrap-datepicker-rails"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 gem "mysql2"
-gem "bootstrap-datepicker-rails"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/app/assets/javascripts/hubstats/users.js
+++ b/app/assets/javascripts/hubstats/users.js
@@ -41,10 +41,6 @@ $(document).ready(function() {
   $("#repocount").on("click", function(){
     toggleOrder(queryParameters,$(this).attr('id'));
   });
-
-  $("#usercount").on("click", function(){
-    toggleOrder(queryParameters,$(this).attr('id'));
-  });
 });
 
 /* toggleOrder

--- a/app/views/hubstats/partials/_team.html.erb
+++ b/app/views/hubstats/partials/_team.html.erb
@@ -11,7 +11,8 @@
   <!-- Show all of the stats for the individual team -->
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
-      <span class="text-large"><%= team.user_count || 0 %></span> <!-- minus one for the user we're using as the access_token -->
+      <span class="text-large"><%= team.users.count_active_developers(@start_date, @end_date) %> /
+                               <%= team.users.count_active_reviewers(@start_date, @end_date) %></span>
     </div>
   </div>
   <div class="col-lg-2 col-md-2 col-sm-2">

--- a/app/views/hubstats/tables/_teams.html.erb
+++ b/app/views/hubstats/tables/_teams.html.erb
@@ -6,7 +6,7 @@
         <a class="header desc" id="name"> Team Name <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="usercount"> Users <span class="octicon"></span> </a>
+        <a class="header desc"> Developers / Reviewers <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>


### PR DESCRIPTION
Description and Impact
----------------------
* Make the team's index page show developers and reviewers count instead of total user count (total user count can still be seen for each individual team's show page)
* Got rid of sorting for users on teams index page

Deploy Plan
-----------
* No new migrations

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
* Just make sure the code looks good
* Test locally that the sorting doesn't exist and that the numbers of developers/reviewers seems accurate
  * Developers can actually be tested if you click into the show page (the # of PRs is existent for each user)
