### PR TITLE
Adding PRs per developer and Comments per reviewer to team page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 gem "mysql2"
+gem "bootstrap-datepicker-rails"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 gem "mysql2"
-gem "bootstrap-datepicker-rails"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/app/assets/javascripts/hubstats/users.js
+++ b/app/assets/javascripts/hubstats/users.js
@@ -38,7 +38,11 @@ $(document).ready(function() {
     toggleOrder(queryParameters,$(this).attr('id'));
   });
 
-  $("#repocount").on("click", function(){
+  $("#pulls_per_dev").on("click", function(){
+    toggleOrder(queryParameters,$(this).attr('id'));
+  });
+
+  $("#comments_per_rev").on("click", function(){
     toggleOrder(queryParameters,$(this).attr('id'));
   });
 });

--- a/app/assets/javascripts/hubstats/users.js
+++ b/app/assets/javascripts/hubstats/users.js
@@ -37,14 +37,6 @@ $(document).ready(function() {
   $("#deletions").on("click", function(){
     toggleOrder(queryParameters,$(this).attr('id'));
   });
-
-  $("#pulls_per_dev").on("click", function(){
-    toggleOrder(queryParameters,$(this).attr('id'));
-  });
-
-  $("#comments_per_rev").on("click", function(){
-    toggleOrder(queryParameters,$(this).attr('id'));
-  });
 });
 
 /* toggleOrder

--- a/app/controllers/hubstats/teams_controller.rb
+++ b/app/controllers/hubstats/teams_controller.rb
@@ -14,7 +14,7 @@ module Hubstats
       else
         @teams = Hubstats::Team.where(hubstats: true).with_all_metrics(@start_date, @end_date)
           .with_id(params[:teams])
-          .custom_order(params[:order])
+          .order_by_name
           .paginate(:page => params[:page], :per_page => 15)
       end
 

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -80,6 +80,7 @@ module Hubstats
     def self.update_teams_in_pulls(days)
       pulls = created_since(days)
       pulls.each {|pull| pull.assign_team_from_user}
+      puts "Finished updating the teams of past pull requests"
     end
 
     # Public - Filters all of the pull requests between start_date and end_date that are the given state

--- a/app/models/hubstats/team.rb
+++ b/app/models/hubstats/team.rb
@@ -23,12 +23,12 @@ module Hubstats
     # end_date - the end of the data range
     # 
     # Returns - count of repos
-    scope :repos_count, lambda {|start_date, end_date|
-      select("hubstats_teams.id as team_id")
-       .select("IFNULL(COUNT(DISTINCT hubstats_pull_requests.repo_id),0) AS repo_count")
-       .joins(sanitize_sql_array(["LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.team_id = hubstats_teams.id AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?) AND hubstats_pull_requests.merged = '1'", start_date, end_date]))
-       .group("hubstats_teams.id")
-    }
+    # scope :repos_count, lambda {|start_date, end_date|
+    #   select("hubstats_teams.id as team_id")
+    #    .select("IFNULL(COUNT(DISTINCT hubstats_pull_requests.repo_id),0) AS repo_count")
+    #    .joins(sanitize_sql_array(["LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.team_id = hubstats_teams.id AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?) AND hubstats_pull_requests.merged = '1'", start_date, end_date]))
+    #    .group("hubstats_teams.id")
+    # }
 
     # Public - Counts all of the merged pull requests for selected team's users that occurred between the start_date and end_date.
     # 
@@ -50,13 +50,13 @@ module Hubstats
     # end_date - the end of the data range
     #
     # Returns - the additions and deletions
-    scope :net_additions_count, lambda {|start_date, end_date|
-      select("hubstats_teams.id as team_id")
-      .select("SUM(IFNULL(hubstats_pull_requests.additions, 0)) AS additions")
-      .select("SUM(IFNULL(hubstats_pull_requests.deletions, 0)) AS deletions")
-      .joins(sanitize_sql_array(["LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.team_id = hubstats_teams.id AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?) AND hubstats_pull_requests.merged = '1'", start_date, end_date]))
-      .group("hubstats_teams.id")
-    }
+    # scope :net_additions_count, lambda {|start_date, end_date|
+    #   select("hubstats_teams.id as team_id")
+    #   .select("SUM(IFNULL(hubstats_pull_requests.additions, 0)) AS additions")
+    #   .select("SUM(IFNULL(hubstats_pull_requests.deletions, 0)) AS deletions")
+    #   .joins(sanitize_sql_array(["LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.team_id = hubstats_teams.id AND (hubstats_pull_requests.merged_at BETWEEN ? AND ?) AND hubstats_pull_requests.merged = '1'", start_date, end_date]))
+    #   .group("hubstats_teams.id")
+    # }
 
     # Public - Joins all of the metrics together for selected team: net additions, comments, repos, and pull requests.
     # 
@@ -64,12 +64,25 @@ module Hubstats
     # end_date - the end of the data range
     # 
     # Returns - all of the stats about the team
+    # scope :with_all_metrics, lambda {|start_date, end_date|
+    #   select("hubstats_teams.*, pull_request_count, comment_count, repo_count, additions, deletions")
+    #    .joins("LEFT JOIN (#{net_additions_count(start_date, end_date).to_sql}) AS net_additions ON net_additions.team_id = hubstats_teams.id")
+    #    .joins("LEFT JOIN (#{pull_requests_count(start_date, end_date).to_sql}) AS pull_requests ON pull_requests.team_id = hubstats_teams.id")
+    #    .joins("LEFT JOIN (#{comments_count(start_date, end_date).to_sql}) AS comments ON comments.team_id = hubstats_teams.id")
+    #    .joins("LEFT JOIN (#{repos_count(start_date, end_date).to_sql}) AS repos ON repos.team_id = hubstats_teams.id")
+    #    .group("hubstats_teams.id")
+    # }
+
+    scope :pulls_per_dev, lambda{
+      select("pull_request_count, cast(pull_request_count as FLOAT)/cast(5 as FLOAT) AS pulls_per_dev")
+       .group("hubstats_teams.id")
+    }
+
     scope :with_all_metrics, lambda {|start_date, end_date|
-      select("hubstats_teams.*, pull_request_count, comment_count, repo_count,additions, deletions")
-       .joins("LEFT JOIN (#{net_additions_count(start_date, end_date).to_sql}) AS net_additions ON net_additions.team_id = hubstats_teams.id")
+      select("hubstats_teams.*, pull_request_count, comment_count, pulls_per_dev")
        .joins("LEFT JOIN (#{pull_requests_count(start_date, end_date).to_sql}) AS pull_requests ON pull_requests.team_id = hubstats_teams.id")
        .joins("LEFT JOIN (#{comments_count(start_date, end_date).to_sql}) AS comments ON comments.team_id = hubstats_teams.id")
-       .joins("LEFT JOIN (#{repos_count(start_date, end_date).to_sql}) AS repos ON repos.team_id = hubstats_teams.id")
+       .joins("LEFT JOIN (#{pulls_per_dev.to_sql}")
        .group("hubstats_teams.id")
     }
 
@@ -125,10 +138,10 @@ module Hubstats
           order("pull_request_count #{order}")
         when 'comments'
           order("comment_count #{order}")
-        when 'netadditions'
-          order("additions - deletions #{order}")
-        when 'repocount'
-          order("repo_count #{order}")
+        when 'pulls_per_dev'
+          order("pulls_per_dev #{order}")
+        when 'comments_per_rev'
+          order("comment_count #{order}")
         when 'name'
           order("name #{order}")
         else

--- a/app/views/hubstats/partials/_quick_addition_stats.html.erb
+++ b/app/views/hubstats/partials/_quick_addition_stats.html.erb
@@ -2,32 +2,32 @@
 <div class="col-lg-<%= (12-(@stats_additions.length)*2)/2 %>"></div>
 
 <% if @stats_additions.has_key? :net_additions %>
-	<div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
-	  <h1> <%= @stats_additions[:net_additions] %> </h1>
-	  <h4> Net Additions </h4>
-	</div>
+  <div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
+    <h1> <%= @stats_additions[:net_additions] %> </h1>
+    <h4> Net Additions </h4>
+  </div>
 <% end %>
 <% if @stats_additions.has_key? :avg_additions %>
-	<div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
-	  <h1> <%= @stats_additions[:avg_additions] %> </h1>
-	  <h4> Average Additions per Pull Request </h4>
-	</div>
+  <div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
+    <h1> <%= @stats_additions[:avg_additions] %> </h1>
+    <h4> Average Additions per Pull Request </h4>
+  </div>
 <% end %>
 <% if @stats_additions.has_key? :avg_deletions%>
-	<div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
-	  <h1><%= @stats_additions[:avg_deletions] %> </h1>
-	  <h4> Average Deletions per Pull Request </h4>
-	</div>
+  <div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
+    <h1><%= @stats_additions[:avg_deletions] %> </h1>
+    <h4> Average Deletions per Pull Request </h4>
+  </div>
 <% end %>
 <% if @stats_additions.has_key? :additions %>
-	<div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
-	  <h1> <%= @stats_additions[:additions] %> </h1>
-	  <h4> Additions </h4>
-	</div>
+  <div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
+    <h1> <%= @stats_additions[:additions] %> </h1>
+    <h4> Additions </h4>
+  </div>
 <% end %>
 <% if @stats_additions.has_key? :deletions%>
-	<div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
-	  <h1><%= @stats_additions[:deletions] %> </h1>
-	  <h4> Deletions </h4>
-	</div>
+  <div class="col col-lg-2 col-md-4 col-sm-4 col-xs-4 text-center">
+    <h1><%= @stats_additions[:deletions] %> </h1>
+    <h4> Deletions </h4>
+  </div>
 <% end %>

--- a/app/views/hubstats/partials/_quick_stats.html.erb
+++ b/app/views/hubstats/partials/_quick_stats.html.erb
@@ -2,62 +2,68 @@
 <div class="col-lg-<%= (12-(@stats_basics.length)*2)/2 %>"></div>
 
 <% if @stats_basics.has_key? :user_count %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1> <%= @stats_basics[:user_count] %> </h1>
-	  <h4> Active Users </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1> <%= @stats_basics[:user_count] %> </h1>
+    <h4> Active Users </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :deploy_count %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1> <%= @stats_basics[:deploy_count] %> </h1>
-	  <h4> Deployments </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1> <%= @stats_basics[:deploy_count] %> </h1>
+    <h4> Deployments </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :pull_count %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1> <%= @stats_basics[:pull_count] %> </h1>
-	  <h4> Merged Pull Requests </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1> <%= @stats_basics[:pull_count] %> </h1>
+    <h4> Merged Pull Requests </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :comment_count %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1><%= @stats_basics[:comment_count] %> </h1>
-	  <h4> Comments </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1><%= @stats_basics[:comment_count] %> </h1>
+    <h4> Comments </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :review_count %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	   <h1> <%= @stats_basics[:review_count] %> </h1>
-	  <h4> Code Reviews </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+     <h1> <%= @stats_basics[:review_count] %> </h1>
+    <h4> Code Reviews </h4>
+  </div>
+<% end %>
+<% if @stats_basics.has_key? :repo_count %>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+     <h1> <%= @stats_basics[:repo_count] %> </h1>
+    <h4> Repositories with Pull Requests or Comments </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :net_additions %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1> <%= @stats_basics[:net_additions] %> </h1>
-	  <h4> Net Additions </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1> <%= @stats_basics[:net_additions] %> </h1>
+    <h4> Net Additions </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :avg_additions %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1> <%= @stats_basics[:avg_additions] %> </h1>
-	  <h4> Average Additions per Pull Request </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1> <%= @stats_basics[:avg_additions] %> </h1>
+    <h4> Average Additions per Pull Request </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :avg_deletions%>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1><%= @stats_basics[:avg_deletions] %> </h1>
-	  <h4> Average Deletions per Pull Request </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1><%= @stats_basics[:avg_deletions] %> </h1>
+    <h4> Average Deletions per Pull Request </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :additions %>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1> <%= @stats_basics[:additions] %> </h1>
-	  <h4> Additions </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1> <%= @stats_basics[:additions] %> </h1>
+    <h4> Additions </h4>
+  </div>
 <% end %>
 <% if @stats_basics.has_key? :deletions%>
-	<div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-	  <h1><%= @stats_basics[:deletions] %> </h1>
-	  <h4> Deletions </h4>
-	</div>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1><%= @stats_basics[:deletions] %> </h1>
+    <h4> Deletions </h4>
+  </div>
 <% end %>

--- a/app/views/hubstats/partials/_team.html.erb
+++ b/app/views/hubstats/partials/_team.html.erb
@@ -23,19 +23,28 @@
   </div>
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
+      <span class="text-large"><% if team.users.count_active_developers(@start_date, @end_date) != 0 %>
+                                 <%= (team.pull_request_count.to_f / team.users.count_active_developers(@start_date, @end_date).to_f).round(2) %>
+                               <% else %>
+                                 <%= 0 %>
+                               <% end %></span>
+      <span class="mega-octicon octicon-git-pull-request"></span>
+    </div>
+  </div>
+  <div class="col-lg-2 col-md-2 col-sm-2">
+    <div class="text-center">
       <span class="text-large"><%= team.comment_count %></span>
       <span class="mega-octicon octicon-comment"></span>
     </div>
   </div>
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
-      <span class="text-large"><%= team.repo_count %></span>
-      <span class="mega-octicon octicon-repo"></span>
-    </div>
-  </div>
-  <div class="col-lg-2 col-md-2 col-sm-2">
-    <div class="text-center">
-      <span class="text-large"><%= team.additions - team.deletions %></span>
+      <span class="text-large"><% if team.users.count_active_reviewers(@start_date, @end_date) != 0 %>
+                                 <%= (team.comment_count.to_f / team.users.count_active_reviewers(@start_date, @end_date).to_f).round(2) %>
+                               <% else %>
+                                 <%= 0 %>
+                               <% end %></span>
+      <span class="mega-octicon octicon-comment"></span>
     </div>
   </div>
 </div>

--- a/app/views/hubstats/tables/_teams.html.erb
+++ b/app/views/hubstats/tables/_teams.html.erb
@@ -3,22 +3,22 @@
   <div class="teams">
     <div class="row single-user header">
       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="name"> Team Name <span class="octicon"></span> </a>
+        <a class="header desc"> Team Name <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc"> Developers / Reviewers <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
+        <a class="header desc"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="pulls_per_dev"> Pull Requests per Developer <span class="octicon"></span></a>
+        <a class="header desc"> Pull Requests per Developer <span class="octicon"></span></a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="comments"> Comments <span class="octicon"></span></a>
+        <a class="header desc"> Comments <span class="octicon"></span></a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="comments_per_rev"> Comments per Reviewer <span class="octicon"></span></a>
+        <a class="header desc"> Comments per Reviewer <span class="octicon"></span></a>
       </div>
     </div>
     <%= render partial: 'hubstats/partials/team', collection: @teams, as: :team %>

--- a/app/views/hubstats/tables/_teams.html.erb
+++ b/app/views/hubstats/tables/_teams.html.erb
@@ -12,13 +12,13 @@
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
+        <a class="header desc" id="pulls_per_dev"> Pull Requests per Developer <span class="octicon"></span></a>
+      </div>
+      <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="comments"> Comments <span class="octicon"></span></a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="repocount"> Repositories <span class="octicon"></span></a>
-      </div>
-      <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="netadditions"> Net Additions <span class="octicon"></span></a>
+        <a class="header desc" id="comments_per_rev"> Comments per Reviewer <span class="octicon"></span></a>
       </div>
     </div>
     <%= render partial: 'hubstats/partials/team', collection: @teams, as: :team %>

--- a/app/views/hubstats/teams/show.html.erb
+++ b/app/views/hubstats/teams/show.html.erb
@@ -5,7 +5,14 @@
     <h1 class="title text-center"><%= @team.name %></a> </h1>
 
     <!-- Show all of the stats about the team -->
-    <%= render 'hubstats/partials/quick_stats' %>
+        <%= render 'hubstats/partials/quick_stats' %>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <%= render 'hubstats/partials/quick_addition_stats' %>
   </div>
 
   <div class="row">

--- a/spec/controllers/hubstats/teams_controller_spec.rb
+++ b/spec/controllers/hubstats/teams_controller_spec.rb
@@ -10,7 +10,7 @@ module Hubstats
         team2 = create(:team, :name => "Team Two", :hubstats => false)
         team3 = create(:team, :name => "Team Three", :hubstats => true)
         team4 = create(:team, :name => "Team Four", :hubstats => true)
-        expect(Hubstats::Team).to receive_message_chain("with_id.custom_order.paginate").and_return([team1, team2, team3, team4])
+        expect(Hubstats::Team).to receive_message_chain("with_id.order_by_name.paginate").and_return([team4, team1, team3, team2])
         allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("ignore_users_list") { ["user"] }
         get :index
         expect(response).to have_http_status(200)


### PR DESCRIPTION
Description and Impact
----------------------
* Make the team's index page show the pull requests per developer and comments per reviewer
* Show the total number of repositories on the team's show page
* Sorting on the team's index page is GONE!

Deploy Plan
-----------
* No new migrations

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
* Just make sure the code looks good
* Test locally that all sorting on the teams' index page is gone
* Check that the math of the new counts are somewhat accurate
