### PR TITLE
Change deployments count to comments count on user condensed page

### DIFF
--- a/app/views/hubstats/partials/_user-condensed.html.erb
+++ b/app/views/hubstats/partials/_user-condensed.html.erb
@@ -20,8 +20,8 @@
   </div>
   <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3">
     <div class="pull-right">
-      <span class="text-large"><%= Hubstats::Deploy.belonging_to_user(user.id).deployed_in_date_range(@start_date, @end_date).count(:all) %></span>
-      <span class="mega-octicon octicon-rocket"></span>
+      <span class="text-large"><%= Hubstats::Comment.belonging_to_user(user.id).created_in_date_range(@start_date, @end_date).count(:all) %></span>
+      <span class="mega-octicon octicon-comment"></span>
     </div>
   </div>
   <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1">


### PR DESCRIPTION
Description and Impact
----------------------
* On the team's show view (on the user's condensed page) the deployment count now shows a comment count for each user

Deploy Plan
-----------
* No new migrations

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
* Check that the count is accurate (go to the user metric page and see what their comment count is)
