### PR TITLE
updated_at shouldn't change when updating teams for pull requests

### DIFF
--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -149,8 +149,7 @@ module Hubstats
     def assign_team_from_user
       user = Hubstats::User.find(self.user_id)
       if user.team && user.team.id
-        self.team_id = user.team.id
-        self.save!
+        self.update_columns(team_id: user.team.id)
       end
     end
 


### PR DESCRIPTION
Description and Impact
----------------------
* Changing way database saves when updating teams for past PRs so that `updated_at` column of `Hubstats::PullRequest` doesn't change when we update teams

Deploy Plan
-----------
* One migration present

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_column

QA Plan
-------
* Test when we get to staging on commissioner