### PR TITLE
Another attempt at fixing bug to correct updated_at timestamp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 gem "mysql2"
-gem "bootstrap-datepicker-rails"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/app/models/hubstats/comment.rb
+++ b/app/models/hubstats/comment.rb
@@ -1,6 +1,8 @@
 module Hubstats
   class Comment < ActiveRecord::Base
 
+    def self.record_timestamps; false; end
+
     # Various checks that can be used to filter and find info about comments.
     scope :created_in_date_range, lambda {|start_date, end_date| where("hubstats_comments.created_at BETWEEN ? AND ?", start_date, end_date)}
     scope :belonging_to_pull_request, lambda {|pull_request_id| where(pull_request_id: pull_request_id)}

--- a/app/models/hubstats/label.rb
+++ b/app/models/hubstats/label.rb
@@ -1,6 +1,8 @@
 module Hubstats
   class Label < ActiveRecord::Base
 
+    def self.record_timestamps; false; end
+
     # Various checks that can be used to filter and find info about labels.
     scope :with_ids, lambda {|pull_ids| (where("hubstats_labels_pull_requests.pull_request_id" => pull_ids))}
     scope :with_state, lambda {|state| (where(state: state) unless state == 'all') if state}

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -149,7 +149,7 @@ module Hubstats
     def assign_team_from_user
       user = Hubstats::User.find(self.user_id)
       if user.team && user.team.id
-        self.update_columns(team_id: user.team.id)
+        self.update_column(:team_id, user.team.id)
       end
     end
 

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -1,5 +1,7 @@
 module Hubstats
   class PullRequest < ActiveRecord::Base
+
+    def self.record_timestamps; false; end
     
     # Various checks that can be used to filter, sort, and find info about pull requests.
     scope :closed_in_date_range, lambda {|start_date, end_date| where("hubstats_pull_requests.closed_at BETWEEN ? AND ?", start_date, end_date)}

--- a/app/models/hubstats/repo.rb
+++ b/app/models/hubstats/repo.rb
@@ -1,6 +1,8 @@
 module Hubstats
   class Repo < ActiveRecord::Base
 
+    def self.record_timestamps; false; end
+
     # Various checks that can be used to filter and find info about repos.
     scope :with_recent_activity, lambda {|start_date, end_date| where("hubstats_repos.updated_at BETWEEN ? AND ?", start_date, end_date).order("updated_at DESC")}
     scope :with_id, lambda {|repo_id| where(id: repo_id.split(',')) if repo_id}

--- a/app/models/hubstats/team.rb
+++ b/app/models/hubstats/team.rb
@@ -1,6 +1,8 @@
 module Hubstats
   class Team < ActiveRecord::Base
 
+    def self.record_timestamps; false; end
+
     scope :with_id, lambda {|team_id| where(id: team_id.split(',')) if team_id}
 
     # Public - Counts all of the comments a selected team's members have written that occurred between the start_date and end_date.

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -165,7 +165,7 @@ module Hubstats
 
     attr_accessible :login, :id, :avatar_url, :gravatar_id, :url, :html_url, :followers_url,
       :following_url, :gists_url, :starred_url, :subscriptions_url, :organizations_url,
-      :repos_url, :events_url, :received_events_url, :role, :site_admin
+      :repos_url, :events_url, :received_events_url, :role, :site_admin, :created_at, :updated_at
     
     validates :id, presence: true, uniqueness: true
 

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -1,6 +1,8 @@
 module Hubstats
   class User < ActiveRecord::Base
 
+    def self.record_timestamps; false; end
+
     # Various checks that can be used to filter and find info about users.
     scope :with_id, lambda {|user_id| where(id: user_id.split(',')) if user_id}
     scope :only_active, having("comment_count > 0 OR pull_request_count > 0 OR deploy_count > 0")

--- a/spec/controllers/hubstats/pull_requests_controller_spec.rb
+++ b/spec/controllers/hubstats/pull_requests_controller_spec.rb
@@ -9,7 +9,8 @@ module Hubstats
         user = build(:user)
         repo = build(:repo)
         pull3 = create(:pull_request, :user => user,
-                                      :repo => repo)
+                                      :repo => repo,
+                                      :created_at => '2015-05-30')
         pull1 = create(:pull_request, :user => user,
                                       :repo => repo)
         pull4 = create(:pull_request, :user => user,

--- a/spec/controllers/hubstats/pull_requests_controller_spec.rb
+++ b/spec/controllers/hubstats/pull_requests_controller_spec.rb
@@ -6,17 +6,20 @@ module Hubstats
     
     describe "#index" do
       it "should correctly order all of the pull requests" do
-        user = build(:user)
-        repo = build(:repo)
+        user = build(:user, :updated_at => '2015-12-01')
+        repo = build(:repo, :updated_at => '2015-12-01')
         pull3 = create(:pull_request, :user => user,
                                       :repo => repo,
-                                      :created_at => '2015-05-30')
+                                      :updated_at => '2015-05-30')
         pull1 = create(:pull_request, :user => user,
-                                      :repo => repo)
+                                      :repo => repo,
+                                      :updated_at => '2015-05-30')
         pull4 = create(:pull_request, :user => user,
-                                      :repo => repo)
+                                      :repo => repo,
+                                      :updated_at => '2015-05-30')
         pull2 = create(:pull_request, :user => user,
-                                      :repo => repo)
+                                      :repo => repo,
+                                      :updated_at => '2015-05-30')
         pulls_ordered = [pull3, pull1, pull4, pull2]
         expect(Hubstats::PullRequest).to receive_message_chain("group_by.with_label.state_based_order.paginate").and_return(pulls_ordered)
         get :index
@@ -27,14 +30,15 @@ module Hubstats
 
     describe "#show" do
       it "should show the comments and deploy of specific pull request" do
-        user = build(:user)
-        repo = build(:repo)
+        user = build(:user, :updated_at => '2015-12-01')
+        repo = build(:repo, :updated_at => '2015-12-01')
         pull = create(:pull_request, :user => user,
                                      :repo => repo,
-                                     :deploy_id => 404040)
-        comment1 = create(:comment, :pull_request_id => pull.id, :created_at => @start_date)
-        comment2 = create(:comment, :pull_request_id => pull.id, :created_at => @start_date)
-        comment3 = create(:comment, :pull_request_id => pull.id, :created_at => @start_date)
+                                     :deploy_id => 404040,
+                                     :updated_at => '2015-05-30')
+        comment1 = create(:comment, :pull_request_id => pull.id, :created_at => Date.today, :updated_at => '2015-12-01', user: user)
+        comment2 = create(:comment, :pull_request_id => pull.id, :created_at => Date.today, :updated_at => '2015-12-01', user: user)
+        comment3 = create(:comment, :pull_request_id => pull.id, :created_at => Date.today, :updated_at => '2015-12-01', user: user)
         get :show, repo: repo, id: pull.id
         expect(assigns(:pull_request)).to eq(pull)
         expect(assigns(:pull_request).repo_id).to eq(101010)

--- a/spec/controllers/hubstats/repos_controller_spec.rb
+++ b/spec/controllers/hubstats/repos_controller_spec.rb
@@ -9,19 +9,19 @@ module Hubstats
         repo1 = create(:repo, :id => 101010,
                               :name => "silly",
                               :full_name => "sportngin/silly",
-                              :updated_at => @start_date)
+                              :updated_at => Date.today)
         repo2 = create(:repo, :id => 202020,
                               :name => "funny",
                               :full_name => "sportngin/funny",
-                              :updated_at => @start_date)
+                              :updated_at => Date.today)
         repo3 = create(:repo, :id => 303030,
                               :name => "loosey",
                               :full_name => "sportngin/loosey",
-                              :updated_at => @start_date)
+                              :updated_at => Date.today)
         repo4 = create(:repo, :id => 404040,
                               :name => "goosey",
                               :full_name => "sportngin/goosey",
-                              :updated_at => @start_date)
+                              :updated_at => Date.today)
         get :index
         expect(assigns(:repos)).to contain_exactly(repo2, repo1, repo3, repo4)
       end
@@ -29,15 +29,18 @@ module Hubstats
 
     describe "#show" do
       it "should show the pull requests and deploys of specific repository" do
+        user = create(:user, :id => 606060, :updated_at => '2015-08-12')
         repo = create(:repo, :id => 101010,
                              :name => "example",
                              :full_name => "sportngin/example",
-                             :owner_id => 606060)
+                             :owner_id => user.id,
+                             :updated_at => Date.today)
         pull1 = create(:pull_request, :repo_id => 101010,
-                                      :updated_at => "2015-06-02 19:49:42")
+                                      :updated_at => "2015-06-02 19:49:42",
+                                      :user => user)
         pull2 = create(:pull_request, :repo_id => 101010,
-                                      :updated_at => "2015-04-21 17:06:31")
-        user = create(:user, :id => 606060)
+                                      :updated_at => "2015-04-21 17:06:31",
+                                      :user => user)
         deploy1 = create(:deploy, :repo_id => 101010)
         deploy2 = create(:deploy, :repo_id => 101010)
         get :show, repo: repo.name
@@ -53,16 +56,20 @@ module Hubstats
       it "should list all of the repos and the basic metrics" do
         repo1 = create(:repo, :id => 101010,
                               :name => "silly",
-                              :full_name => "sportngin/silly")
+                              :full_name => "sportngin/silly",
+                              :updated_at => Date.today)
         repo2 = create(:repo, :id => 202020,
                               :name => "funny",
-                              :full_name => "sportngin/funny")
+                              :full_name => "sportngin/funny",
+                              :updated_at => Date.today)
         repo3 = create(:repo, :id => 303030,
                               :name => "loosey",
-                              :full_name => "sportngin/loosey")
+                              :full_name => "sportngin/loosey",
+                              :updated_at => Date.today)
         repo4 = create(:repo, :id => 404040,
                               :name => "goosey",
-                              :full_name => "sportngin/goosey")
+                              :full_name => "sportngin/goosey",
+                              :updated_at => Date.today)
         expect(Hubstats::Repo).to receive_message_chain("with_id.custom_order.paginate").and_return([repo1, repo2, repo3, repo4])
         get :index
         expect(response).to have_http_status(200)

--- a/spec/controllers/hubstats/teams_controller_spec.rb
+++ b/spec/controllers/hubstats/teams_controller_spec.rb
@@ -20,12 +20,13 @@ module Hubstats
     describe "#show" do
       it "should return the team and all of its users and pull requests" do
         team = create(:team, :name => "Team Tests Passing", :hubstats => true, :id => 1)
-        user1 = create(:user, :id => 101010, :login => "examplePerson1")
-        user2 = create(:user, :id => 202020, :login => "examplePerson2")
+        user1 = create(:user, :id => 101010, :login => "examplePerson1", :updated_at => Date.today)
+        user2 = create(:user, :id => 202020, :login => "examplePerson2", :updated_at => Date.today)
+        repo = create(:repo, :updated_at => Date.today)
         team.users << user1
         team.users << user2
-        pull1 = create(:pull_request, :user => user1, :id => 303030, :team => team)
-        pull2 = create(:pull_request, :user => user2, :id => 404040, :team => team, :repo => pull1.repo)
+        pull1 = create(:pull_request, :user => user1, :id => 303030, :team => team, :repo_id => repo.id, :updated_at => Date.today)
+        pull2 = create(:pull_request, :user => user2, :id => 404040, :team => team, :repo => pull1.repo, :updated_at => Date.today)
         allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("ignore_users_list") { ["user"] }
         get :show, id: 1
         expect(assigns(:team)).to eq(team)

--- a/spec/controllers/hubstats/users_controller_spec.rb
+++ b/spec/controllers/hubstats/users_controller_spec.rb
@@ -6,10 +6,10 @@ module Hubstats
 
     describe "#index" do
       it "should show all of the users" do
-        user2 = create(:user, :id => 101010, :login => "examplePerson1")
-        user1 = create(:user, :id => 202020, :login => "examplePerson2")
-        user3 = create(:user, :id => 303030, :login => "examplePerson3")
-        user4 = create(:user, :id => 404040, :login => "examplePerson4")
+        user2 = create(:user, :id => 101010, :login => "examplePerson1", :updated_at => Date.today)
+        user1 = create(:user, :id => 202020, :login => "examplePerson2", :updated_at => Date.today)
+        user3 = create(:user, :id => 303030, :login => "examplePerson3", :updated_at => Date.today)
+        user4 = create(:user, :id => 404040, :login => "examplePerson4", :updated_at => Date.today)
         expect(Hubstats::User).to receive_message_chain("with_id.custom_order.paginate").and_return([user2, user3, user1, user4])
         get :index
         expect(response).to have_http_status(200)
@@ -18,13 +18,14 @@ module Hubstats
 
     describe "#show" do
       it "should show the pull requests and deploys of specific user" do
-        user = create(:user, :id => 101010, :login => "examplePerson")
-        pull1 = create(:pull_request, :user => user, :id => 202020)
-        pull2 = create(:pull_request, :user => user, :id => 303030, :repo => pull1.repo)
+        user = create(:user, :id => 101010, :login => "examplePerson", :updated_at => Date.today)
+        repo = create(:repo, :updated_at => Date.today)
+        pull1 = create(:pull_request, :user => user, :id => 202020, :updated_at => Date.today, :repo_id => repo.id)
+        pull2 = create(:pull_request, :user => user, :id => 303030, :repo => pull1.repo, :updated_at => Date.today)
         deploy1 = create(:deploy, :user_id => 101010)
         deploy2 = create(:deploy, :user_id => 101010)
-        comment1 = create(:comment, :user => user)
-        comment2 = create(:comment, :user => user)
+        comment1 = create(:comment, :user => user, :updated_at => Date.today)
+        comment2 = create(:comment, :user => user, :updated_at => Date.today)
         get :show, id: "examplePerson"
         expect(assigns(:user)).to eq(user)
         expect(assigns(:user).pull_requests).to contain_exactly(pull1, pull2)

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -4,13 +4,15 @@ FactoryGirl.define do
     user
     id {Faker::Number.number(6).to_i}
     body {Faker::Lorem.sentence}
+    created_at '2015-05-30'
   end
 
   factory :comment_hash, class:Hash do
     association :user, factory: :user_hash, strategy: :build
     id {Faker::Number.number(6).to_i}
     body {Faker::Lorem.sentence}
-    initialize_with { attributes } 
+    initialize_with { attributes }
+    created_at '2015-05-30' 
   end
 
   factory :comment_payload_hash, class:Hash do 
@@ -19,6 +21,7 @@ FactoryGirl.define do
     association :repository, factory: :repo_hash, strategy: :build
     association :pull_request, factory: :pull_request_hash, strategy: :build
     association :comment, factory: :comment_hash, strategy: :build
+    created_at '2015-05-30'
     initialize_with { attributes } 
   end 
 end

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -12,16 +12,15 @@ FactoryGirl.define do
     id {Faker::Number.number(6).to_i}
     body {Faker::Lorem.sentence}
     initialize_with { attributes }
-    created_at '2015-05-30' 
   end
 
   factory :comment_payload_hash, class:Hash do 
     id {Faker::Number.number(6).to_i}
     type ["IssueCommentEvent", "CommitCommentEvent", "PullRequestReviewCommentEvent"].sample
+    association :user, factory: :user_hash, strategy: :build
     association :repository, factory: :repo_hash, strategy: :build
     association :pull_request, factory: :pull_request_hash, strategy: :build
     association :comment, factory: :comment_hash, strategy: :build
-    created_at '2015-05-30'
     initialize_with { attributes } 
   end 
 end

--- a/spec/factories/pull_requests.rb
+++ b/spec/factories/pull_requests.rb
@@ -14,8 +14,8 @@ FactoryGirl.define do
     id {Faker::Number.number(6).to_i}
     number {|n| "#{n}".to_i}
     merged_by(:id => 202020)
-    created_at '2015-05-30'
-
+    created_at Date.today
+    updated_at Date.today
     initialize_with { attributes } 
   end
 
@@ -25,8 +25,8 @@ FactoryGirl.define do
     id {Faker::Number.number(6).to_i}
     number {|n| "#{n}".to_i}
     merged_by(nil)
-    created_at '2015-05-30'
-
+    created_at Date.today
+    updated_at Date.today
     initialize_with { attributes } 
   end
 
@@ -36,8 +36,6 @@ FactoryGirl.define do
     association :repository, factory: :repo_hash, strategy: :build
     association :pull_request, factory: :pull_request_hash, strategy: :build
     merged_by(:id => 202020)
-    created_at '2015-05-30'
-
     initialize_with { attributes } 
   end
 end

--- a/spec/factories/pull_requests.rb
+++ b/spec/factories/pull_requests.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     repo
     id {Faker::Number.number(6).to_i}
     number {|n| "#{n}".to_i}
+    created_at '2015-05-30'
   end
 
   factory :pull_request_hash, class:Hash do
@@ -13,6 +14,7 @@ FactoryGirl.define do
     id {Faker::Number.number(6).to_i}
     number {|n| "#{n}".to_i}
     merged_by(:id => 202020)
+    created_at '2015-05-30'
 
     initialize_with { attributes } 
   end
@@ -23,6 +25,7 @@ FactoryGirl.define do
     id {Faker::Number.number(6).to_i}
     number {|n| "#{n}".to_i}
     merged_by(nil)
+    created_at '2015-05-30'
 
     initialize_with { attributes } 
   end
@@ -33,6 +36,7 @@ FactoryGirl.define do
     association :repository, factory: :repo_hash, strategy: :build
     association :pull_request, factory: :pull_request_hash, strategy: :build
     merged_by(:id => 202020)
+    created_at '2015-05-30'
 
     initialize_with { attributes } 
   end

--- a/spec/factories/repo.rb
+++ b/spec/factories/repo.rb
@@ -4,12 +4,14 @@ FactoryGirl.define do
     id 101010
     name "hubstats"
     full_name "hub/hubstats"
+    created_at '2015-05-30'
   end
 
   factory :repo_hash, class:Hash do
     id 101010
     name "Hubstats"
     full_name "hub/hubstats"
+    created_at '2015-05-30'
 
     initialize_with { attributes } 
   end

--- a/spec/factories/repo.rb
+++ b/spec/factories/repo.rb
@@ -11,8 +11,6 @@ FactoryGirl.define do
     id 101010
     name "Hubstats"
     full_name "hub/hubstats"
-    created_at '2015-05-30'
-
     initialize_with { attributes } 
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,8 +11,6 @@ FactoryGirl.define do
     login { Faker::Internet.user_name }
     id {|n| "#{n}".to_i}
     role "User"
-    created_at '2015-05-30'
-
     initialize_with { attributes } 
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,12 +4,14 @@ FactoryGirl.define do
     login { Faker::Internet.user_name }
     id {|n| "#{n}".to_i}
     role "User"
+    created_at '2015-05-30'
   end
 
   factory :user_hash, class:Hash do
     login { Faker::Internet.user_name }
     id {|n| "#{n}".to_i}
     role "User"
+    created_at '2015-05-30'
 
     initialize_with { attributes } 
   end

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 module Hubstats
   describe EventsHandler, :type => :model do
     context "PullRequestEvent" do
-      let(:pull) {build(:pull_request)}
-      let(:repo) {build(:repo)}
+      let(:user) {build(:user, :updated_at => Date.today)}
+      let(:repo) {build(:repo, :updated_at => Date.today)}
+      let(:pull) {build(:pull_request, :updated_at => Date.today, :user => user, :repo => repo)}
       let(:payload) {build(:pull_request_payload_hash)}
 
       subject {Hubstats::EventsHandler.new()}
@@ -23,6 +24,8 @@ module Hubstats
     end
 
     context "CommentEvent" do
+      let(:user) {build(:user, :updated_at => Date.today, :created_at => '2015-01-01', :login => "hermina", :id => 0, :role => "User")}
+
       it 'should successfully route the event' do
         ehandler = EventsHandler.new()
         payload = build(:comment_payload_hash)
@@ -39,7 +42,11 @@ module Hubstats
 
       it 'should successfully creates_or_updates the event' do
         ehandler = Hubstats::EventsHandler.new()
-        payload = build(:comment_payload_hash)
+        payload = build(:comment_payload_hash, :user => {:login=>"hermina", :id=>0, :role=>"User"},
+                                               :comment => {"id"=>194761, "body"=>"Quidem ea minus ut odio optio.",
+                                                            "kind"=>"Issue", "user_id"=>0, "repo_id"=>101010,
+                                                            "created_at" => Date.today, "updated_at" => Date.today})
+        allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
         expect(ehandler.route(payload, payload[:type]).class).to eq(Hubstats::Comment)
       end
     end

--- a/spec/lib/hubstats/github_api_spec.rb
+++ b/spec/lib/hubstats/github_api_spec.rb
@@ -78,6 +78,7 @@ module Hubstats
       let(:user1) {build(:user_hash)}
       let(:user2) {build(:user_hash)}
       let(:user3) {build(:user_hash)}
+      let(:finished_user) {build(:user, :created_at => Date.today, :updated_at => Date.today)}
       let(:hubstats_user) {build(:user)}
       let(:access_token) { "access_token" }
       let(:user) { double }
@@ -94,6 +95,7 @@ module Hubstats
         allow(Hubstats::Team).to receive_message_chain(:where, :name).with("Team One")
         allow(Hubstats::Team.where(name: "Team One")).to receive(:first).and_return(team)
         allow(client).to receive_message_chain(:rate_limit, :remaining).and_return(500)
+        allow(Hubstats::User).to receive(:create_or_update).and_return(finished_user)
         expect(Hubstats::Team).to receive(:create_or_update).at_least(:once)
         subject.update_teams
       end

--- a/spec/models/hubstats/comment_spec.rb
+++ b/spec/models/hubstats/comment_spec.rb
@@ -3,21 +3,13 @@ require 'spec_helper'
 module Hubstats
   describe Comment, :type => :model do
     it 'should create and return a comment and user' do
-      github_user = {:login => "elliothursh",
-                     :id => 10,
-                    :type => "User"}
-      github_comment = {:user => github_user,
-                        :pull_request_url => "www.pull.com",
-                        :id => 100}
-      github_repo = {:id => 151,
-                     :name => "HelloWorld"}
-      pull_request = {:id => 1000,
-                      :url => "www.pull.com",
-                      :repository => github_repo,
-                      :user => github_user}
-      repo = Repo.create_or_update(github_repo)
-      pull = PullRequest.create_or_update(pull_request)
-      comment = Comment.create_or_update(github_comment)
+      repo = build(:repo, :created_at => Date.today, :updated_at => Date.today)
+      user = build(:user, :created_at => Date.today, :updated_at => Date.today,
+                   :login => "elliothursh", :id => 10)
+      comment = build(:comment, :created_at => Date.today, :updated_at => Date.today,
+                      :user => user, :pull_request_url => "www.pull.com", :id => 100, :repo => repo)
+      pull_request = build(:pull_request, :created_at => Date.today, :updated_at => Date.today,
+                           :id => 1000, :url => "www.pull.com", :repo => repo, :user => user)
       expect(comment.id).to eq(100)
       expect(comment.user_id).to eq(10)
     end

--- a/spec/models/hubstats/pull_request_spec.rb
+++ b/spec/models/hubstats/pull_request_spec.rb
@@ -4,6 +4,10 @@ module Hubstats
   describe PullRequest, :type => :model do
     it 'should create and return a pull request with a merge' do
       pull = build(:pull_request_hash)
+      user = create(:user, :created_at => Date.today, :updated_at => Date.today)
+      repo = create(:repo, :created_at => Date.today, :updated_at => Date.today)
+      allow(Hubstats::User).to receive(:create_or_update).and_return(user)
+      allow(Hubstats::Repo).to receive(:create_or_update).and_return(repo)
       pull_request = PullRequest.create_or_update(pull)
       expect(pull_request.id).to eq(pull[:id])
       expect(pull_request.user_id).to eq(pull[:user][:id])
@@ -14,6 +18,10 @@ module Hubstats
 
     it 'should create and return a pull request without a merge' do
       pull = build(:pull_request_hash_no_merge)
+      user = create(:user, :created_at => Date.today, :updated_at => Date.today)
+      repo = create(:repo, :created_at => Date.today, :updated_at => Date.today)
+      allow(Hubstats::User).to receive(:create_or_update).and_return(user)
+      allow(Hubstats::Repo).to receive(:create_or_update).and_return(repo)
       pull_request = PullRequest.create_or_update(pull)
       expect(pull_request.id).to eq(pull[:id])
       expect(pull_request.user_id).to eq(pull[:user][:id])
@@ -23,7 +31,11 @@ module Hubstats
     end
 
     it "should create a pull request and update the deploy's user_id" do
+      user = create(:user, :created_at => Date.today, :updated_at => Date.today)
+      repo = create(:repo, :created_at => Date.today, :updated_at => Date.today)
       pull = build(:pull_request_hash)
+      allow(Hubstats::User).to receive(:create_or_update).and_return(user)
+      allow(Hubstats::Repo).to receive(:create_or_update).and_return(repo)
       pull_request = PullRequest.create_or_update(pull)
       dep_hash = {git_revision: "c1a2b37", 
                   repo_id: 303030,
@@ -44,10 +56,13 @@ module Hubstats
 
     it "should track the team_id when making a pull request" do
       user_hash = {login: 'name', id: '12345'}
-      user = User.create(user_hash)
+      user = create(:user, :created_at => Date.today, :updated_at => Date.today)
+      repo = create(:repo, :created_at => Date.today, :updated_at => Date.today)
       team = create(:team, id: 1010)
       team.users << user
       pull = build(:pull_request_hash, :user => user_hash)
+      allow(Hubstats::User).to receive(:create_or_update).and_return(user)
+      allow(Hubstats::Repo).to receive(:create_or_update).and_return(repo)
       pull_request = PullRequest.create_or_update(pull)
       expect(pull_request.user_id).to eq(user[:id])
       expect(pull_request.team_id).to eq(team[:id])
@@ -55,8 +70,11 @@ module Hubstats
 
     it "should leave the team_id of a pull request blank if user is not part of a team" do
       user_hash = {login: 'name', id: '12345'}
-      user = User.create(user_hash, created_at: '2015-05-30')
+      repo = create(:repo, :created_at => Date.today, :updated_at => Date.today)
+      user = build(:user, :created_at => Date.today, :updated_at => Date.today)
       pull = build(:pull_request_hash, :user => user_hash)
+      allow(Hubstats::User).to receive(:create_or_update).and_return(user)
+      allow(Hubstats::Repo).to receive(:create_or_update).and_return(repo)
       pull_request = PullRequest.create_or_update(pull)
       expect(pull_request.user_id).to eq(user[:id])
       expect(pull_request.team_id).to eq(nil)
@@ -64,12 +82,12 @@ module Hubstats
 
     it 'should update the team_ids in pull requests' do
       team = build(:team)
-      repo = build(:repo)
+      repo = build(:repo, :updated_at => Date.today)
       user1 = build(:user)
       user2 = build(:user, :id => 7)
       team.users << user1
       team.users << user2
-      pull1 = build(:pull_request, :created_at => Date.today - 250, :user => user1)
+      pull1 = build(:pull_request, :created_at => Date.today - 250, :user => user1, :repo => repo)
       pull2 = build(:pull_request, :created_at => Date.today - 3, :repo => repo, :user => user2)
       Hubstats::PullRequest.update_teams_in_pulls(365)
       expect(pull1.team_id).to eq(team.id)

--- a/spec/models/hubstats/pull_request_spec.rb
+++ b/spec/models/hubstats/pull_request_spec.rb
@@ -55,7 +55,7 @@ module Hubstats
 
     it "should leave the team_id of a pull request blank if user is not part of a team" do
       user_hash = {login: 'name', id: '12345'}
-      user = User.create(user_hash)
+      user = User.create(user_hash, created_at: '2015-05-30')
       pull = build(:pull_request_hash, :user => user_hash)
       pull_request = PullRequest.create_or_update(pull)
       expect(pull_request.user_id).to eq(user[:id])

--- a/spec/models/hubstats/team_spec.rb
+++ b/spec/models/hubstats/team_spec.rb
@@ -12,7 +12,7 @@ module Hubstats
     end
 
     it 'should add a member to a team' do
-      user = build(:user)
+      user = build(:user, :created_at => Date.today, :updated_at => Date.today)
       action = "added"
       team = build(:team)
       Hubstats::Team.update_users_in_team(team, user, action)

--- a/spec/models/hubstats/user_spec.rb
+++ b/spec/models/hubstats/user_spec.rb
@@ -7,13 +7,13 @@ module Hubstats
     end
 
     it 'should create and return a user' do
-      user = build(:user_hash, id: 10)
+      user = build(:user_hash, id: 10, :created_at => Date.today, :updated_at => Date.today)
       expect(User.create_or_update(user).id).to eq(10)
     end
 
     it 'should update a user based off id' do
-      user1 = User.create_or_update(build(:user_hash, login: 'johnappleseed', id: 10))
-      user2 = User.create_or_update(build(:user_hash, login: 'johndoe', id: 10))
+      user1 = User.create_or_update(build(:user_hash, login: 'johnappleseed', id: 10, :created_at => Date.today, :updated_at => Date.today))
+      user2 = User.create_or_update(build(:user_hash, login: 'johndoe', id: 10, :created_at => Date.today, :updated_at => Date.today))
       expect(user1).to eq(user2)
       expect(user2.login).to eq("johndoe")
       expect(user1.login).not_to eq("johnapplesdeed")
@@ -21,7 +21,7 @@ module Hubstats
 
     it 'should find the team that this user belongs to' do
       team = create(:team)
-      user = create(:user, login: 'janedoe', id: 11)
+      user = create(:user, login: 'janedoe', id: 11, :created_at => Date.today, :updated_at => Date.today)
       team.users << user
       expect(user.login).to eq('janedoe')
       expect(user.team).to eq(team)
@@ -30,7 +30,7 @@ module Hubstats
     it 'should find first team that this user belongs to' do
       team1 = create(:team, name: "sad")
       team2 = create(:team, name: "happy")
-      user = create(:user, login: 'janedoe', id: 11)
+      user = create(:user, login: 'janedoe', id: 11, :created_at => Date.today, :updated_at => Date.today)
       team1.users << user
       team2.users << user
       expect(user.login).to eq('janedoe')
@@ -39,7 +39,7 @@ module Hubstats
 
     it 'should return no team if the hubstats bool is false' do
       team = create(:team, hubstats: false)
-      user = create(:user, login: 'janedoe', id: 11)
+      user = create(:user, login: 'janedoe', id: 11, :created_at => Date.today, :updated_at => Date.today)
       team.users << user
       expect(user.login).to eq('janedoe')
       expect(user.team).to eq(nil)


### PR DESCRIPTION
Description and Impact
----------------------
* Added line to file that will turn off the automatic updating of `updated_at` because we want `updated_at` to reference Github's version of `updated_at` instead of rails' `updated_at`.

Deploy Plan
-----------
* Zero migrations present

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----

QA Plan
-------
* Test when it goes out to commissioner staging