### PR TITLE
Fixing bug that makes metrics not show up on teams and repos page

### DIFF
--- a/app/controllers/hubstats/repos_controller.rb
+++ b/app/controllers/hubstats/repos_controller.rb
@@ -1,7 +1,7 @@
 require_dependency "hubstats/application_controller"
 
 module Hubstats
-  class ReposController < Hubstats::BaseController
+  class ReposController < ApplicationController
 
     # Public - Shows all of the repos, in either alphabetical order, by filter params, or that have done things in
     # github between the selected @start_date and @end_date.

--- a/app/controllers/hubstats/teams_controller.rb
+++ b/app/controllers/hubstats/teams_controller.rb
@@ -1,7 +1,7 @@
 require_dependency "hubstats/application_controller"
 
 module Hubstats
-  class TeamsController < Hubstats::BaseController
+  class TeamsController < ApplicationController
 
     # Public - Shows all of the teams in either alphabetical order, by filter params, or that have done things in
     # github between the selected @start_date and @end_date.


### PR DESCRIPTION
Description and Impact
----------------------
This will fix a bug that hopefully will allow the teams and repos page to show up successfully with the metrics.

Deploy Plan
-----------
Zero migrations present

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----

QA Plan
-------
* Check it out on staging