### PR TITLE
Fixing bug that resulted in no data being updated from org webhooks

### DIFF
--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -7,7 +7,7 @@ module Hubstats
     # type - the type of data that payload is
     #
     # Returns - nothing
-    def route(payload, type) 
+    def route(payload, type)
       case type
       when "issue_comment", "IssueCommentEvent"
         comment_processor(payload, "Issue")
@@ -55,15 +55,13 @@ module Hubstats
     #
     # Returns - nothing, but updates or makes the team
     def team_processor(payload)
-      team = payload[:team]
-      team[:action] = payload[:action]
-      team[:current_user] = payload[:member]
+      team = payload[:event][:team]
       team_list = Hubstats.config.github_config["team_list"] || []
       if team_list.include? team[:name]
         Hubstats::Team.create_or_update(team.with_indifferent_access)
         hubstats_team = Hubstats::Team.where(name: team[:name]).first
-        hubstats_user = Hubstats::User.create_or_update(team[:current_user])
-        Hubstats::Team.update_users_in_team(hubstats_team, hubstats_user, team[:action])
+        hubstats_user = Hubstats::User.create_or_update(payload[:event][:member])
+        Hubstats::Team.update_users_in_team(hubstats_team, hubstats_user, payload[:event][:action])
       end
     end
 

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -64,10 +64,14 @@ module Hubstats
         payload = build(:team_payload_hash)
         user = build(:user)
         allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("team_list") { ["Team One", "Team Two", "Team Three"] }
+        allow(payload).to receive(:[]).with(:event).and_return(payload)
+        allow(payload).to receive(:[]).with(:team).and_return({:name => "Team One"})
+        allow(payload).to receive(:[]).with(:member).and_return(user)
+        allow(payload).to receive(:[]).with(:action).and_return("added")
         allow(Hubstats::User).to receive(:create_or_update).and_return(user)
         expect(Hubstats::Team).to receive(:create_or_update)
         expect(Hubstats::Team).to receive(:update_users_in_team)
-        ehandler.route(payload, payload[:type])
+        ehandler.route(payload, "MembershipEvent")
       end
 
       it 'should successfully create_or_update the team' do
@@ -77,9 +81,13 @@ module Hubstats
         user = build(:user)
         allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("team_list") { ["Team One", "Team Two", "Team Three"] }
         allow(Hubstats::User).to receive(:create_or_update).and_return(user)
+        allow(payload).to receive(:[]).with(:event).and_return(payload)
+        allow(payload).to receive(:[]).with(:team).and_return({:name => "Team One"})
+        allow(payload).to receive(:[]).with(:member).and_return(user)
+        allow(payload).to receive(:[]).with(:action).and_return("added")
         expect(Hubstats::Team).to receive(:update_users_in_team)
         expect(Hubstats::Team).to receive(:create_or_update).and_return(team)
-        ehandler.route(payload, payload[:type])
+        ehandler.route(payload, "MembershipEvent")
       end
     end
 


### PR DESCRIPTION
Description and Impact
----------------------
Hopefully, this will enable teams to actually be updated with users whenever an organization membership webhook comes in. Previously, the webhooks were successfully passed, but they were not being processed correctly.

Deploy Plan
-----------
Zero migrations present.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
1. Put on staging
2. Send an organization webhook
3. Watch the log to see if it is processed successfully, and then refresh the team page to see if the new user appears