### PR TITLE
Yet another attempt at fixing GitHub org webhooks bug

### DIFF
--- a/app/controllers/hubstats/events_controller.rb
+++ b/app/controllers/hubstats/events_controller.rb
@@ -15,9 +15,8 @@ module Hubstats
       kind = request.headers['X-Github-Event']
       event = params.with_indifferent_access
 
-      raw_payload = request.raw_post
-      original_payload = JSON.parse(raw_payload)
-      event[:github_action] = original_payload["action"]
+      raw_parameters = request.request_parameters
+      event[:github_action] = raw_parameters["action"]
 
       eventsHandler = Hubstats::EventsHandler.new()
       eventsHandler.route(event,kind)


### PR DESCRIPTION
Description and Impact
----------------------
Another attempt at fixing the bug that is making the org webhooks error or not process correctly.

Deploy Plan
-----------
No new migrations present.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
[API that talks about both `raw_post` and `request_parameters`](http://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters)
[Various chats about `raw_post` not working and returning nil (which was the error we got when we tried our last attempt)](https://github.com/rails/rails/issues/11345)
[More `raw_post` not working](https://github.com/torquebox/torquebox/commit/12946313c0d9bb230c237af3e4f17c36ae275f91)
QA Plan
-------
* Put on staging and try another webhook
* Watch the log on the server to try to catch any erring
* UPDATE! It worked on staging! This version of the org webhooks is ready to go out!
