### PR TITLE
making sure mysql2 version is within 0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
-gem "mysql2"
+gem "mysql2", "~> 0.3.10"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing


### PR DESCRIPTION
Description and Impact
----------------------
Mysql2 version is updating to 0.4.0 when bundling, but Hubstats is set to run with ~>0.3.10. So updating Gemfile to only allow ~>0.3.10.

Deploy Plan
-----------
No new migrations present.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----

QA Plan
-------
* Just test that everything bundles locally, and then try running the tests and serving locally.
