### PR TITLE
Restrict mysql2 dependency to compatible version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
-gem "mysql2", "~> 0.3.10"
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/hubstats.gemspec
+++ b/hubstats.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "select2-rails", "3.5.9"
   s.add_dependency "bootstrap-datepicker-rails", "~> 1.4.0"
 
+  s.add_development_dependency "mysql2",'~> 0.3.20'
   s.add_development_dependency "rspec-rails",'~> 3.0.0.beta'
   s.add_development_dependency "shoulda-matchers", "~> 2.6"
   s.add_development_dependency "factory_girl_rails", "~> 4.4"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150721193128) do
+ActiveRecord::Schema.define(:version => 20150721192612) do
 
   create_table "hubstats_comments", :force => true do |t|
     t.string   "kind"


### PR DESCRIPTION
Description and Impact
----------------------
This rails engine gem is developed in Rails 3.2.x and the new mysql2 0.4.x is not compatible.  Locking down to a compatible version in the gemspec so that it works for local development and Travis CI.

https://github.com/rails/rails/issues/21544
https://github.com/brianmario/mysql2/issues/675
https://travis-ci.org/sportngin/hubstats/jobs/80271570
