### PR TITLE
Change comment body to be text instead of string

### DIFF
--- a/db/migrate/20160113175649_add_body_text_column_to_comments.rb
+++ b/db/migrate/20160113175649_add_body_text_column_to_comments.rb
@@ -1,0 +1,5 @@
+class AddBodyTextColumnToComments < ActiveRecord::Migration
+  def change
+  	add_column :hubstats_comments, :body_text, :text
+  end
+end

--- a/db/migrate/20160113181700_copy_body_string_to_body_text.rb
+++ b/db/migrate/20160113181700_copy_body_string_to_body_text.rb
@@ -1,5 +1,9 @@
 class CopyBodyStringToBodyText < ActiveRecord::Migration
-  def change
+  def self.up
      Hubstats::Comment.update_all("body_text=body")
+  end
+
+  def self.down
+  	Hubstats::Comment.update_all("body=body_text")
   end
 end

--- a/db/migrate/20160113181700_copy_body_string_to_body_text.rb
+++ b/db/migrate/20160113181700_copy_body_string_to_body_text.rb
@@ -1,0 +1,5 @@
+class CopyBodyStringToBodyText < ActiveRecord::Migration
+  def change
+     Hubstats::Comment.update_all("body_text=body")
+  end
+end

--- a/db/migrate/20160113182307_rename_body_to_body_string.rb
+++ b/db/migrate/20160113182307_rename_body_to_body_string.rb
@@ -1,0 +1,5 @@
+class RenameBodyToBodyString < ActiveRecord::Migration
+  def change
+  	rename_column :hubstats_comments, :body, :body_string
+  end
+end

--- a/db/migrate/20160113182356_rename_body_text_to_body.rb
+++ b/db/migrate/20160113182356_rename_body_text_to_body.rb
@@ -1,0 +1,5 @@
+class RenameBodyTextToBody < ActiveRecord::Migration
+  def change
+  	rename_column :hubstats_comments, :body_text, :body
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -9,113 +9,114 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160112162918) do
+ActiveRecord::Schema.define(version: 20160113182419) do
 
-  create_table "hubstats_comments", :force => true do |t|
-    t.string   "kind"
-    t.integer  "user_id"
-    t.integer  "pull_request_id"
-    t.integer  "repo_id"
+  create_table "hubstats_comments", force: :cascade do |t|
+    t.string   "html_url",         limit: 255
+    t.string   "url",              limit: 255
+    t.string   "pull_request_url", limit: 255
+    t.integer  "path",             limit: 4
+    t.string   "body_string",      limit: 255
+    t.string   "kind",             limit: 255
+    t.integer  "user_id",          limit: 4
+    t.integer  "pull_request_id",  limit: 4
+    t.integer  "repo_id",          limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "body"
-    t.integer  "path"
-    t.string   "html_url"
-    t.string   "url"
-    t.string   "pull_request_url"
+    t.text     "body",             limit: 65535
   end
 
-  add_index "hubstats_comments", ["pull_request_id"], :name => "index_hubstats_comments_on_pull_request_id"
-  add_index "hubstats_comments", ["user_id"], :name => "index_hubstats_comments_on_user_id"
+  add_index "hubstats_comments", ["pull_request_id"], name: "index_hubstats_comments_on_pull_request_id", using: :btree
+  add_index "hubstats_comments", ["user_id"], name: "index_hubstats_comments_on_user_id", using: :btree
 
-  create_table "hubstats_deploys", :force => true do |t|
-    t.string   "git_revision"
-    t.integer  "repo_id"
+  create_table "hubstats_deploys", force: :cascade do |t|
+    t.string   "git_revision", limit: 255
+    t.integer  "repo_id",      limit: 4
     t.datetime "deployed_at"
-    t.integer  "user_id"
+    t.integer  "user_id",      limit: 4
   end
 
-  add_index "hubstats_deploys", ["repo_id"], :name => "index_hubstats_deploys_on_repo_id"
-  add_index "hubstats_deploys", ["user_id"], :name => "index_hubstats_deploys_on_user_id"
+  add_index "hubstats_deploys", ["repo_id"], name: "index_hubstats_deploys_on_repo_id", using: :btree
+  add_index "hubstats_deploys", ["user_id"], name: "index_hubstats_deploys_on_user_id", using: :btree
 
-  create_table "hubstats_labels", :force => true do |t|
-    t.string "name"
-    t.string "color"
-    t.string "url"
+  create_table "hubstats_labels", force: :cascade do |t|
+    t.string "name",  limit: 255
+    t.string "color", limit: 255
+    t.string "url",   limit: 255
   end
 
-  create_table "hubstats_labels_pull_requests", :force => true do |t|
-    t.integer "pull_request_id"
-    t.integer "label_id"
+  create_table "hubstats_labels_pull_requests", force: :cascade do |t|
+    t.integer "pull_request_id", limit: 4
+    t.integer "label_id",        limit: 4
   end
 
-  add_index "hubstats_labels_pull_requests", ["label_id"], :name => "index_hubstats_labels_pull_requests_on_label_id"
-  add_index "hubstats_labels_pull_requests", ["pull_request_id"], :name => "index_hubstats_labels_pull_requests_on_pull_request_id"
+  add_index "hubstats_labels_pull_requests", ["label_id"], name: "index_hubstats_labels_pull_requests_on_label_id", using: :btree
+  add_index "hubstats_labels_pull_requests", ["pull_request_id"], name: "index_hubstats_labels_pull_requests_on_pull_request_id", using: :btree
 
-  create_table "hubstats_pull_requests", :force => true do |t|
-    t.integer  "number"
-    t.integer  "user_id"
-    t.integer  "repo_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "hubstats_pull_requests", force: :cascade do |t|
+    t.string   "url",        limit: 255
+    t.string   "html_url",   limit: 255
+    t.string   "issue_url",  limit: 255
+    t.integer  "number",     limit: 4
+    t.string   "state",      limit: 255
+    t.string   "title",      limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.datetime "closed_at"
-    t.integer  "additions"
-    t.integer  "deletions"
-    t.integer  "comments"
-    t.string   "url"
-    t.string   "html_url"
-    t.string   "issue_url"
-    t.string   "state"
-    t.string   "title"
-    t.string   "merged"
-    t.integer  "deploy_id"
-    t.integer  "merged_by"
+    t.string   "merged",     limit: 255
+    t.integer  "comments",   limit: 4
+    t.integer  "additions",  limit: 4
+    t.integer  "deletions",  limit: 4
+    t.integer  "user_id",    limit: 4
+    t.integer  "repo_id",    limit: 4
+    t.integer  "deploy_id",  limit: 4
+    t.integer  "merged_by",  limit: 4
     t.datetime "merged_at"
-    t.integer  "team_id"
+    t.integer  "team_id",    limit: 4
   end
 
-  add_index "hubstats_pull_requests", ["deploy_id"], :name => "index_hubstats_pull_requests_on_deploy_id"
-  add_index "hubstats_pull_requests", ["repo_id"], :name => "index_hubstats_pull_requests_on_repo_id"
-  add_index "hubstats_pull_requests", ["team_id"], :name => "index_hubstats_pull_requests_on_team_id"
-  add_index "hubstats_pull_requests", ["user_id"], :name => "index_hubstats_pull_requests_on_user_id"
+  add_index "hubstats_pull_requests", ["deploy_id"], name: "index_hubstats_pull_requests_on_deploy_id", using: :btree
+  add_index "hubstats_pull_requests", ["repo_id"], name: "index_hubstats_pull_requests_on_repo_id", using: :btree
+  add_index "hubstats_pull_requests", ["team_id"], name: "index_hubstats_pull_requests_on_team_id", using: :btree
+  add_index "hubstats_pull_requests", ["user_id"], name: "index_hubstats_pull_requests_on_user_id", using: :btree
 
-  create_table "hubstats_repos", :force => true do |t|
-    t.integer  "owner_id"
-    t.string   "name"
-    t.string   "full_name"
+  create_table "hubstats_repos", force: :cascade do |t|
+    t.string   "name",       limit: 255
+    t.string   "full_name",  limit: 255
+    t.string   "url",        limit: 255
+    t.string   "html_url",   limit: 255
+    t.string   "labels_url", limit: 255
     t.datetime "pushed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "url"
-    t.string   "html_url"
-    t.string   "labels_url"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "owner_id",   limit: 4
   end
 
-  add_index "hubstats_repos", ["owner_id"], :name => "index_hubstats_repos_on_owner_id"
+  add_index "hubstats_repos", ["owner_id"], name: "index_hubstats_repos_on_owner_id", using: :btree
 
-  create_table "hubstats_teams", :force => true do |t|
-    t.string  "name"
+  create_table "hubstats_teams", force: :cascade do |t|
+    t.string  "name",     limit: 255
     t.boolean "hubstats"
   end
 
-  create_table "hubstats_teams_users", :force => true do |t|
-    t.integer "user_id"
-    t.integer "team_id"
+  create_table "hubstats_teams_users", force: :cascade do |t|
+    t.integer "user_id", limit: 4
+    t.integer "team_id", limit: 4
   end
 
-  add_index "hubstats_teams_users", ["team_id"], :name => "index_hubstats_teams_users_on_team_id"
-  add_index "hubstats_teams_users", ["user_id"], :name => "index_hubstats_teams_users_on_user_id"
+  add_index "hubstats_teams_users", ["team_id"], name: "index_hubstats_teams_users_on_team_id", using: :btree
+  add_index "hubstats_teams_users", ["user_id"], name: "index_hubstats_teams_users_on_user_id", using: :btree
 
-  create_table "hubstats_users", :force => true do |t|
-    t.string   "login"
-    t.string   "role"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-    t.string   "avatar_url"
-    t.string   "url"
-    t.string   "html_url"
+  create_table "hubstats_users", force: :cascade do |t|
+    t.string   "login",      limit: 255
+    t.string   "avatar_url", limit: 255
+    t.string   "url",        limit: 255
+    t.string   "html_url",   limit: 255
+    t.string   "role",       limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
 end


### PR DESCRIPTION
Description and Impact
----------------------
No visible change for production.
Comment bodies are now text instead of strings.

Deploy Plan
-----------
* Deploy with migrations
* Check that database fields are accurate now with two body columns (one string values and one text values)

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
- [x] Test it locally
