### PR TITLE
Fixing bug that allowed users to be shown multiple times on teams show page

### DIFF
--- a/app/controllers/hubstats/teams_controller.rb
+++ b/app/controllers/hubstats/teams_controller.rb
@@ -33,7 +33,7 @@ module Hubstats
       @team = Hubstats::Team.where(id: params[:id]).first
       @pull_requests = Hubstats::PullRequest.belonging_to_team(@team.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(20)
       @pull_count = Hubstats::PullRequest.belonging_to_team(@team.id).merged_in_date_range(@start_date, @end_date).count(:all)
-      @users = @team.users.where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"]).order("login ASC").uniq
+      @users = @team.users.where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"]).order("login ASC").distinct
       @active_user_count = @users.length
       @comment_count = Hubstats::Comment.belonging_to_team(@users.pluck(:id)).created_in_date_range(@start_date, @end_date).count(:all)
       repos_pr = @pull_requests.pluck(:repo_id)

--- a/app/controllers/hubstats/teams_controller.rb
+++ b/app/controllers/hubstats/teams_controller.rb
@@ -33,7 +33,7 @@ module Hubstats
       @team = Hubstats::Team.where(id: params[:id]).first
       @pull_requests = Hubstats::PullRequest.belonging_to_team(@team.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(20)
       @pull_count = Hubstats::PullRequest.belonging_to_team(@team.id).merged_in_date_range(@start_date, @end_date).count(:all)
-      @users = @team.users.where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"]).order("login ASC")
+      @users = @team.users.where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"]).order("login ASC").uniq
       @active_user_count = @users.length
       @comment_count = Hubstats::Comment.belonging_to_team(@users.pluck(:id)).created_in_date_range(@start_date, @end_date).count(:all)
       repos_pr = @pull_requests.pluck(:repo_id)

--- a/spec/controllers/hubstats/teams_controller_spec.rb
+++ b/spec/controllers/hubstats/teams_controller_spec.rb
@@ -35,6 +35,7 @@ module Hubstats
         expect(pull1.team_id).to eq(team.id)
         expect(pull2.team_id).to eq(team.id)
         expect(assigns(:team).users).to contain_exactly(user1, user2, user2)
+        expect(assigns(:users)).to contain_exactly(user1, user2)
         expect(assigns(:active_user_count)).to eq(2)
         expect(response).to have_http_status(200)
       end

--- a/spec/controllers/hubstats/teams_controller_spec.rb
+++ b/spec/controllers/hubstats/teams_controller_spec.rb
@@ -23,9 +23,9 @@ module Hubstats
         team = create(:team, :name => "Team Tests Passing", :hubstats => true, :id => 1)
         user1 = create(:user, :id => 101010, :login => "examplePerson1", :updated_at => Date.today)
         user2 = create(:user, :id => 202020, :login => "examplePerson2", :updated_at => Date.today)
-        user22 = create(:user, :id => 202021, :login => "examplePerson2", :updated_at => Date.today)
         repo = create(:repo, :updated_at => Date.today)
         team.users << user1
+        team.users << user2
         team.users << user2
         pull1 = create(:pull_request, :user => user1, :id => 303030, :team => team, :repo_id => repo.id, :updated_at => Date.today)
         pull2 = create(:pull_request, :user => user2, :id => 404040, :team => team, :repo => pull1.repo, :updated_at => Date.today)
@@ -34,7 +34,8 @@ module Hubstats
         expect(assigns(:team)).to eq(team)
         expect(pull1.team_id).to eq(team.id)
         expect(pull2.team_id).to eq(team.id)
-        expect(assigns(:team).users).to contain_exactly(user1, user2)
+        expect(assigns(:team).users).to contain_exactly(user1, user2, user2)
+        expect(assigns(:active_user_count)).to eq(2)
         expect(response).to have_http_status(200)
       end
     end

--- a/spec/controllers/hubstats/teams_controller_spec.rb
+++ b/spec/controllers/hubstats/teams_controller_spec.rb
@@ -23,6 +23,7 @@ module Hubstats
         team = create(:team, :name => "Team Tests Passing", :hubstats => true, :id => 1)
         user1 = create(:user, :id => 101010, :login => "examplePerson1", :updated_at => Date.today)
         user2 = create(:user, :id => 202020, :login => "examplePerson2", :updated_at => Date.today)
+        user22 = create(:user, :id => 202021, :login => "examplePerson2", :updated_at => Date.today)
         repo = create(:repo, :updated_at => Date.today)
         team.users << user1
         team.users << user2


### PR DESCRIPTION
Description and Impact
----------------------
No more this! (There aren't three anfleene's)
![screen shot 2016-01-14 at 2 20 15 pm](https://cloud.githubusercontent.com/assets/7562793/12336401/0218a56a-baca-11e5-9d05-81c605d648cc.png)

Deploy Plan
-----------
No migrations present

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
* just know that this works (you can check it out locally)