### PR TITLE
Sort decorators for consistent behavior

### DIFF
--- a/lib/hubstats/engine.rb
+++ b/lib/hubstats/engine.rb
@@ -7,7 +7,7 @@ module Hubstats
     end
 
     config.to_prepare do
-      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |c|
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").sort.each do |c|
         require_dependency(c)
       end
       ApplicationController.helper(MetricsHelper)


### PR DESCRIPTION
Force a alphabetical sort of decorator files so behavior is consistent between OSX and Linux.  Inconsistent sorting can cause weird and hard to troubleshoot bugs.