### PR TITLE
Improved handling of labeling/unlabeling a PR

### DIFF
--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -27,7 +27,7 @@ module Hubstats
     belongs_to :repo
     belongs_to :deploy
     belongs_to :team
-    has_and_belongs_to_many :labels, :join_table => "hubstats_labels_pull_requests"
+    has_and_belongs_to_many :labels, ->{ uniq }, :join_table => "hubstats_labels_pull_requests"
 
     # Public - Makes a new pull request from a GitHub webhook. Finds user_id and repo_id based on users and repos 
     # that are already in the Hubstats database. Updates the user_id of a deploy if the pull request has been merged in a deploy.
@@ -167,7 +167,7 @@ module Hubstats
       label = Hubstats::Label.first_or_create(payload[:label])
       if payload[:action] == 'labeled'
         labels << label
-      elsif
+      elsif payload[:action] == 'unlabeled'
         labels.delete(label)
       end
       labels

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -54,10 +54,10 @@ module Hubstats
       if github_pull[:merged_by] && github_pull[:merged_by][:id]
         pull_data[:merged_by] = github_pull[:merged_by][:id]
         deploy = Hubstats::Deploy.where(id: pull.deploy_id, user_id: nil).first
-          if deploy
-            deploy.user_id = pull_data[:merged_by]
-            deploy.save!
-          end
+        if deploy
+          deploy.user_id = pull_data[:merged_by]
+          deploy.save!
+        end
       end
 
       if user.team && user.team.id
@@ -155,8 +155,22 @@ module Hubstats
     #
     # Returns - the new labels
     def add_labels(labels)
-      labels.map!{|label| Hubstats::Label.first_or_create(label) }
+      labels.map! { |label| Hubstats::Label.first_or_create(label) }
       self.labels = labels
+    end
+
+    # Public - Adds/remove a label based on the the webhook action
+    # @param payload Webhook payload#
+    # @return The list of labels after the update
+    def update_label(payload)
+      return unless payload[:label]
+      label = Hubstats::Label.first_or_create(payload[:label])
+      if payload[:action] == 'labeled'
+        labels << label
+      elsif
+        labels.delete(label)
+      end
+      labels
     end
   end
 end

--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -35,6 +35,7 @@ module Hubstats
       labels = Hubstats::GithubAPI.get_labels_for_pull(repo_name, new_pull.number)
       process_label_change(labels, payload) if payload[:action].include?('labeled') # When a new label is added/removed
       new_pull.add_labels(labels)
+      new_pull.save!
     end
 
     # Public - Gets the information for the new comment and updates it

--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -276,7 +276,7 @@ module Hubstats
       end
     end
 
-    # Public - Routes to the correst setup methods to be used to update or create comments or PRs
+    # Public - Routes to the correct setup methods to be used to update or create comments or PRs
     #
     # object - the new thing to be updated or created
     # kind - the type of thing (pull comment, issue comment, normal comment, pull, or issue)

--- a/spec/factories/pull_requests.rb
+++ b/spec/factories/pull_requests.rb
@@ -39,15 +39,4 @@ FactoryGirl.define do
     merged_by(:id => 202020)
     initialize_with { attributes } 
   end
-
-  factory :pull_request_labeled_payload_hash, class:Hash do
-    id {Faker::Number.number(6).to_i}
-    type "PullRequestEvent"
-    action 'labeled'
-    label {{name: 'new_label'}}
-    association :repository, factory: :repo_hash, strategy: :build
-    association :pull_request, factory: :pull_request_hash, strategy: :build
-    merged_by(:id => 202020)
-    initialize_with { attributes }
-  end
 end

--- a/spec/factories/pull_requests.rb
+++ b/spec/factories/pull_requests.rb
@@ -33,9 +33,21 @@ FactoryGirl.define do
   factory :pull_request_payload_hash, class:Hash do 
     id {Faker::Number.number(6).to_i}
     type "PullRequestEvent"
+    action 'opened'
     association :repository, factory: :repo_hash, strategy: :build
     association :pull_request, factory: :pull_request_hash, strategy: :build
     merged_by(:id => 202020)
     initialize_with { attributes } 
+  end
+
+  factory :pull_request_labeled_payload_hash, class:Hash do
+    id {Faker::Number.number(6).to_i}
+    type "PullRequestEvent"
+    action 'labeled'
+    label {{name: 'new_label'}}
+    association :repository, factory: :repo_hash, strategy: :build
+    association :pull_request, factory: :pull_request_hash, strategy: :build
+    merged_by(:id => 202020)
+    initialize_with { attributes }
   end
 end

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -28,7 +28,7 @@ module Hubstats
         allow(PullRequest).to receive(:create_or_update) {pull}
         allow(Repo).to receive(:where) {[repo,repo]}
         allow(GithubAPI).to receive(:get_labels_for_pull) {[{name: 'low'}, {name: 'high'}]}
-        expect(pull).to receive(:add_labels).with([{name: 'low'}, {name: 'high'}, {name: 'new_label'}])
+        expect(pull).to receive(:update_label).with(payload)
         subject.route(payload, payload[:type])
       end
 
@@ -38,7 +38,7 @@ module Hubstats
         allow(PullRequest).to receive(:create_or_update) {pull}
         allow(Repo).to receive(:where) {[repo,repo]}
         allow(GithubAPI).to receive(:get_labels_for_pull) {[{name: 'low'}, {name: 'high'}, {name: 'old_label'}]}
-        expect(pull).to receive(:add_labels).with([{name: 'low'}, {name: 'high'}])
+        expect(pull).to receive(:update_label).with(payload)
         subject.route(payload, payload[:type])
       end
     end

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -17,8 +17,28 @@ module Hubstats
       it 'should add labels to pull request' do
         allow(PullRequest).to receive(:create_or_update) {pull}
         allow(Repo).to receive(:where) {[repo,repo]}
-        allow(GithubAPI).to receive(:get_labels_for_pull) {['low','high']}
-        expect(pull).to receive(:add_labels).with(['low','high'])
+        allow(GithubAPI).to receive(:get_labels_for_pull) {[{name: 'low'}, {name: 'high'}]}
+        expect(pull).to receive(:add_labels).with([{name: 'low'}, {name: 'high'}])
+        subject.route(payload, payload[:type])
+      end
+
+      it 'should add new labels to pull requests' do
+        payload[:action] = 'labeled'
+        payload[:label] = {name: 'new_label'}
+        allow(PullRequest).to receive(:create_or_update) {pull}
+        allow(Repo).to receive(:where) {[repo,repo]}
+        allow(GithubAPI).to receive(:get_labels_for_pull) {[{name: 'low'}, {name: 'high'}]}
+        expect(pull).to receive(:add_labels).with([{name: 'low'}, {name: 'high'}, {name: 'new_label'}])
+        subject.route(payload, payload[:type])
+      end
+
+      it 'should remove old labels from pull requests' do
+        payload[:action] = 'unlabeled'
+        payload[:label] = {name: 'old_label'}
+        allow(PullRequest).to receive(:create_or_update) {pull}
+        allow(Repo).to receive(:where) {[repo,repo]}
+        allow(GithubAPI).to receive(:get_labels_for_pull) {[{name: 'low'}, {name: 'high'}, {name: 'old_label'}]}
+        expect(pull).to receive(:add_labels).with([{name: 'low'}, {name: 'high'}])
         subject.route(payload, payload[:type])
       end
     end


### PR DESCRIPTION
Description and Impact
----------------------
This PR should hopefully, fix the issue with the `deployable` label occasionally not being applied to a PR.

Hubstats receives a webhook with the type `pull_request` for when a label is added to a PR. The old code would then make an API call to Github to pull all the labels associated with that PR. It is very likely that Github API sometimes doesn't have that new label in the API response.

The changes made here will use the data within the webhook itself to add the new label (or remove an old label) to the PR.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
- [ ] Monitor Hubstats on staging to make sure this didn't break anything. Hopefully there will instances of deployable PRs on staging that aren't on production.

