### PR TITLE
Links to the PR show page should instead route to GitHub

### DIFF
--- a/app/views/hubstats/partials/_pull-condensed.html.erb
+++ b/app/views/hubstats/partials/_pull-condensed.html.erb
@@ -7,7 +7,7 @@
   <div class="pull-info col-lg-9 col-md-9 col-sm-9 col-xs-8">
     <h4> 
       <%= link_to pull.repo.name, repo_path(pull.repo.name) %> /
-      <%= link_to pull.title, pull.html_url %> 
+      <%= link_to pull.title, pull.html_url, :target => '_blank' %>
     </h4>
     by <%= link_to pull.user.login, user_path(pull.user) %>
     <% if pull.merged == '1'%>

--- a/app/views/hubstats/partials/_pull-condensed.html.erb
+++ b/app/views/hubstats/partials/_pull-condensed.html.erb
@@ -7,7 +7,7 @@
   <div class="pull-info col-lg-9 col-md-9 col-sm-9 col-xs-8">
     <h4> 
       <%= link_to pull.repo.name, repo_path(pull.repo.name) %> /
-      <%= link_to pull.title, repo_pull_path({:repo => pull.repo.name, :id => pull.id}) %> 
+      <%= link_to pull.title, pull.html_url %> 
     </h4>
     by <%= link_to pull.user.login, user_path(pull.user) %>
     <% if pull.merged == '1'%>
@@ -22,10 +22,8 @@
   <!-- Show the pull request number and a link to the github PR -->
   <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2" >
     <div class="pull-right">
-      <%= pull.number %> 
-      <a class="subtle" href=<%= pull.html_url %> > 
-        <span class="octicon octicon-mark-github"></span>
-      </a>
+      <%= pull.number %>
+      <span class="octicon octicon-mark-github"></span>
       </span>
     </div>
   </div>

--- a/app/views/hubstats/partials/_pull.html.erb
+++ b/app/views/hubstats/partials/_pull.html.erb
@@ -5,9 +5,9 @@
 
   <!-- Show the repo name and the title of the PR, labels, and who made it when -->
   <div class="pull-info col-lg-9 col-md-9 col-sm-9">
-    <h4> 
+    <h4>
       <%= link_to pull.repo.name, repo_path(pull.repo.name) %> / 
-      <%= link_to pull.title, repo_pull_path({:repo => pull.repo.name, :id => pull.id}) %> 
+      <%= link_to pull.title, pull.html_url %>
     </h4>
     <% pull.labels.each do |label| %>
       <span class="color-label badge" title=<%=label.color%> ><%= label.name %></span>
@@ -26,10 +26,8 @@
   <!-- Show the PR number and a link to the github PR -->
   <div class="col-lg-2 col-md-2 col-sm-2" >
     <div class="pull-right">
-      <%= pull.number %> 
-      <a class="subtle" href=<%= pull.html_url %> > 
-        <span class="octicon octicon-mark-github"></span>
-      </a>
+      <%= pull.number %>
+      <span class="octicon octicon-mark-github"></span>
       </span>
     </div>
   </div>

--- a/app/views/hubstats/partials/_pull.html.erb
+++ b/app/views/hubstats/partials/_pull.html.erb
@@ -7,7 +7,7 @@
   <div class="pull-info col-lg-9 col-md-9 col-sm-9">
     <h4>
       <%= link_to pull.repo.name, repo_path(pull.repo.name) %> / 
-      <%= link_to pull.title, pull.html_url %>
+      <%= link_to pull.title, pull.html_url, :target => '_blank' %>
     </h4>
     <% pull.labels.each do |label| %>
       <span class="color-label badge" title=<%=label.color%> ><%= label.name %></span>


### PR DESCRIPTION
Description and Impact
----------------------
This is a request from the SportsEngine team because we find it's easier to just go straight to GitHub instead of looking at the condensed view of the PR in Hubstats. So any time we are seeing a list of PRs, we just want the title to link directly to GitHub.

Deploy Plan
-----------
* `git checkout master`
* `op accept-pull 107`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Check it out locally that the new routes work correctly

