### PR TITLE
Fixing error where updating teams does not grab all of organization's teams

### DIFF
--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -97,9 +97,9 @@ module Hubstats
     def self.update_teams
       grab_size = 250
       begin
-        client = Hubstats::GithubAPI.client
         Octokit.auto_paginate = true
-        all_teams_in_org = Hubstats::GithubAPI.client.organization_teams(Hubstats.config.github_config["org_name"])
+        client = Hubstats::GithubAPI.client
+        all_teams_in_org = client.organization_teams(Hubstats.config.github_config["org_name"])
         team_list = Hubstats.config.github_config["team_list"] || []
 
         all_teams_in_org.each do |team|

--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -98,7 +98,8 @@ module Hubstats
       grab_size = 250
       begin
         client = Hubstats::GithubAPI.client
-        all_teams_in_org = client.organization_teams(Hubstats.config.github_config["org_name"])
+        Octokit.auto_paginate = true
+        all_teams_in_org = Hubstats::GithubAPI.client.organization_teams(Hubstats.config.github_config["org_name"])
         team_list = Hubstats.config.github_config["team_list"] || []
 
         all_teams_in_org.each do |team|


### PR DESCRIPTION
Description and Impact
----------------------
This fixes an error where when we attempt to update teams, not all of our organization's teams are grabbed (only the first 30). Now, all of them will be grabbed.

Deploy Plan
-----------
* `git checkout master`
* `op accept-pull <pull request ID>`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] In /test/dummy, verify that running `bundle exec rake hubstats:update_teams` makes new teams or at least (if a puts statement is added) grabs more than just 30 repos