### PR TITLE
Add a way to show a QA Signoff count on Users list page

### DIFF
--- a/app/assets/javascripts/hubstats/users.js
+++ b/app/assets/javascripts/hubstats/users.js
@@ -26,6 +26,10 @@ $(document).ready(function() {
     toggleOrder(queryParameters,$(this).attr('id'));
   });
 
+  $("#signoffs").on("click", function(){
+    toggleOrder(queryParameters,$(this).attr('id'));
+  });
+
   $("#netadditions").on("click", function(){
     toggleOrder(queryParameters,$(this).attr('id'));
   });

--- a/app/controllers/hubstats/events_controller.rb
+++ b/app/controllers/hubstats/events_controller.rb
@@ -17,7 +17,6 @@ module Hubstats
 
       raw_parameters = request.request_parameters
       event[:github_action] = raw_parameters["action"]
-      Rails.logger.warn "\n\n\n\n\n ---------------- \n #{event.inspect} \n\n\n -----------"
 
       eventsHandler = Hubstats::EventsHandler.new()
       eventsHandler.route(event, kind)

--- a/app/controllers/hubstats/events_controller.rb
+++ b/app/controllers/hubstats/events_controller.rb
@@ -17,6 +17,7 @@ module Hubstats
 
       raw_parameters = request.request_parameters
       event[:github_action] = raw_parameters["action"]
+      Rails.logger.warn "\n\n\n\n\n ---------------- \n #{event.inspect} \n\n\n -----------"
 
       eventsHandler = Hubstats::EventsHandler.new()
       eventsHandler.route(event, kind)

--- a/app/controllers/hubstats/qa_signoffs_controller.rb
+++ b/app/controllers/hubstats/qa_signoffs_controller.rb
@@ -9,6 +9,7 @@ module Hubstats
     def index
       @qa_signoffs = Hubstats::QaSignoff.includes(:repo, :pull_request, :user)
         .belonging_to_users(params[:users])
+        .belonging_to_repos(params[:repos])
         .group_by(params[:group])
         .paginate(:page => params[:page], :per_page => 15)
 

--- a/app/controllers/hubstats/qa_signoffs_controller.rb
+++ b/app/controllers/hubstats/qa_signoffs_controller.rb
@@ -7,7 +7,7 @@ module Hubstats
     #
     # Returns - the QA Signoff data
     def index
-      @qa_signoffs = Hubstats::QaSignoffs.includes(:repo, :pull_request, :user)
+      @qa_signoffs = Hubstats::QaSignoff.includes(:repo, :pull_request, :user)
         .belonging_to_users(params[:users])
         .group_by(params[:group])
         .paginate(:page => params[:page], :per_page => 15)

--- a/app/controllers/hubstats/qa_signoffs_controller.rb
+++ b/app/controllers/hubstats/qa_signoffs_controller.rb
@@ -1,0 +1,27 @@
+require_dependency "hubstats/application_controller"
+
+module Hubstats
+  class QaSignoffsController < Hubstats::BaseController
+
+    # Public - Will list all of the QA Signoffs that belong to any specific user(s)
+    #
+    # Returns - the QA Signoff data
+    def index
+      @qa_signoffs = Hubstats::QaSignoffs.includes(:repo, :pull_request, :user)
+        .belonging_to_users(params[:users])
+        .group_by(params[:group])
+        .paginate(:page => params[:page], :per_page => 15)
+
+      grouping(params[:group], @qa_signoffs)
+    end 
+
+    # Public - Will show the particular QA Signoff selected
+    #
+    # Returns - the specific details of the QA Signoff
+    def show
+      @repo = Hubstats::Repo.where(id: params[:repo_id]).first
+      @pull_request = Hubstats::PullRequest.where(id: params[:pull_request_id]).first
+      @user = Hubstats::User.where(id: params[:user_id]).first
+    end
+  end
+end

--- a/app/controllers/hubstats/users_controller.rb
+++ b/app/controllers/hubstats/users_controller.rb
@@ -35,6 +35,7 @@ module Hubstats
       @pull_count = Hubstats::PullRequest.belonging_to_user(@user.id).merged_in_date_range(@start_date, @end_date).count(:all)
       @deploys = Hubstats::Deploy.belonging_to_user(@user.id).deployed_in_date_range(@start_date, @end_date).order("deployed_at DESC").limit(20)
       @deploy_count = Hubstats::Deploy.belonging_to_user(@user.id).deployed_in_date_range(@start_date, @end_date).count(:all)
+      @qa_signoff_count = Hubstats::QaSignoff.belonging_to_user(@user_id).signed_within_date_range(@start_date, @end_date).count(:all)
       @comment_count = Hubstats::Comment.belonging_to_user(@user.id).created_in_date_range(@start_date, @end_date).count(:all)
       @net_additions = Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_user(@user.id).sum(:additions).to_i -
                        Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_user(@user.id).sum(:deletions).to_i

--- a/app/controllers/hubstats/users_controller.rb
+++ b/app/controllers/hubstats/users_controller.rb
@@ -35,7 +35,7 @@ module Hubstats
       @pull_count = Hubstats::PullRequest.belonging_to_user(@user.id).merged_in_date_range(@start_date, @end_date).count(:all)
       @deploys = Hubstats::Deploy.belonging_to_user(@user.id).deployed_in_date_range(@start_date, @end_date).order("deployed_at DESC").limit(20)
       @deploy_count = Hubstats::Deploy.belonging_to_user(@user.id).deployed_in_date_range(@start_date, @end_date).count(:all)
-      @qa_signoff_count = Hubstats::QaSignoff.belonging_to_user(@user_id).signed_within_date_range(@start_date, @end_date).count(:all)
+      @qa_signoff_count = Hubstats::QaSignoff.belonging_to_user(@user.id).signed_within_date_range(@start_date, @end_date).count(:all)
       @comment_count = Hubstats::Comment.belonging_to_user(@user.id).created_in_date_range(@start_date, @end_date).count(:all)
       @net_additions = Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_user(@user.id).sum(:additions).to_i -
                        Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_user(@user.id).sum(:deletions).to_i
@@ -55,6 +55,9 @@ module Hubstats
         pull_count: @pull_count,
         deploy_count: @deploy_count,
         comment_count: @comment_count,
+        qa_signoff_count: @qa_signoff_count
+      }
+      @stats_row_two = {
         avg_additions: @additions.round.to_i,
         avg_deletions: @deletions.round.to_i,
         net_additions: @net_additions

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -160,7 +160,7 @@ module Hubstats
     end
 
     # Public - Adds/remove a label based on the the webhook action
-    # @param payload Webhook payload#
+    # @param payload Webhook
     # @return The list of labels after the update
     def update_label(payload)
       return unless payload[:label]

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -42,7 +42,8 @@ module Hubstats
     #
     # Returns - the deleted QA Signoff
     def self.remove_signoff(repo_id, pr_id)
-      signoff = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id).first.destroy
+      signoff = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id).first
+      signoff.destroy if signoff
       signoff.save!
     end
   end

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -44,7 +44,6 @@ module Hubstats
     def self.remove_signoff(repo_id, pr_id)
       signoff = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id).first
       signoff.destroy if signoff
-      signoff.save!
     end
   end
 end

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -28,11 +28,11 @@ module Hubstats
     #
     # Returns - the QA Signoff
     def self.first_or_create(repo_id, pr_id, user_id)
-      QaSignoff.new(user_id: user_id,
-                    repo_id: repo_id,
-                    pull_request_id: pr_id,
-                    label_name: 'qa-approved',
-                    signed_at: Time.now.getutc)
+      QaSignoff.create(user_id: user_id,
+                       repo_id: repo_id,
+                       pull_request_id: pr_id,
+                       label_name: 'qa-approved',
+                       signed_at: Time.now.getutc)
     end
 
     # Public - Deletes the QA Signoff of the PR that is passed in.
@@ -42,7 +42,8 @@ module Hubstats
     #
     # Returns - the deleted QA Signoff
     def self.remove_signoff(repo_id, pr_id)
-      Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id).first.destroy
+      signoff = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id).first.destroy
+      signoff.save!
     end
   end
 end

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -28,8 +28,21 @@ module Hubstats
     #
     # Returns - the QA Signoff
     def self.first_or_create(repo_id, pr_id, user_id)
-      signed_at = Hubstats::PullRequest.find(pr_id).merged_at
-      QaSignoff.new(user_id: user_id, repo_id: repo_id, pr_id: pr_id, label_name: 'qa-approved', signed_at: signed_at)
+      QaSignoff.new(user_id: user_id,
+                    repo_id: repo_id,
+                    pull_request_id: pr_id,
+                    label_name: 'qa-approved',
+                    signed_at: Time.now.getutc)
+    end
+
+    # Public - Deletes the QA Signoff of the PR that is passed in.
+    #
+    # repo_id - the id of the repository the PR belongs to
+    # pr_id - the id of the PR the signoff was deleted from
+    #
+    # Returns - the deleted QA Signoff
+    def self.remove_signoff(repo_id, pr_id)
+      Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id).first.destroy
     end
   end
 end

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -1,0 +1,35 @@
+module Hubstats
+  class QaSignoff < ActiveRecord::Base
+
+    def self.record_timestamps; false; end
+    
+    # Various checks that can be used to filter, sort, and find info about QA Signoffs.
+    scope :signed_within_date_range, lambda {|start_date, end_date| where("hubstats_qa_signoffs.signed_at BETWEEN ? AND ?", start_date, end_date)}
+    scope :belonging_to_repo, lambda {|repo_id| where(repo_id: repo_id)}
+    scope :belonging_to_user, lambda {|user_id| where(user_id: user_id)}
+    scope :belonging_to_pull_request, lambda {|pr_id| where(pull_request_id: pr_id)}
+    scope :belonging_to_repos, lambda {|repo_id| where(repo_id: repo_id.split(',')) if repo_id}
+    scope :belonging_to_users, lambda {|user_id| where(user_id: user_id.split(',')) if user_id}
+    scope :belonging_to_pull_requests, lambda {|pr_id| where(pull_request_id: pr_id.split(',')) if pr_id}
+    scope :distincter, -> { select("DISTINCT hubstats_qa_signoffs.*") }
+    scope :with_repo_name, -> { select('DISTINCT hubstats_repos.name as repo_name, hubstats_qa_signoffs.*').joins("LEFT JOIN hubstats_repos ON hubstats_repos.id = hubstats_qa_signoffs.repo_id") }
+    scope :with_user_name, -> { select('DISTINCT hubstats_users.login as user_name, hubstats_qa_signoffs.*').joins("LEFT JOIN hubstats_users ON hubstats_users.id = hubstats_qa_signoffs.user_id") }
+    scope :with_pull_request_name, -> { select('DISTINCT hubstats_pull_requests.title as pr_name, hubstats_qa_signoffs.*').joins("LEFT JOIN hubstats_pull_requests ON hubstats_pull_requests.id = hubstats_qa_signoffs.pull_request_id") }
+
+    belongs_to :user
+    belongs_to :repo
+    belongs_to :pull_request
+
+    # Public - Makes a new QA Signoff with the data that is passed in.
+    #
+    # repo_id - the id of the repository
+    # pr_id - the id of the pull request
+    # user_id - the id of the user who added the label
+    #
+    # Returns - the QA Signoff
+    def self.first_or_create(repo_id, pr_id, user_id)
+      signed_at = Hubstats::PullRequest.find(pr_id).merged_at
+      QaSignoff.new(user_id: user_id, repo_id: repo_id, pr_id: pr_id, label_name: 'qa-approved', signed_at: signed_at)
+    end
+  end
+end

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -236,6 +236,8 @@ module Hubstats
           order("pull_request_count #{order}")
         when 'comments'
           order("comment_count #{order}")
+        when 'signoffs'
+          order("qa_signoff_count #{order}")
         when 'netadditions'
           order("additions - deletions #{order}")
         when 'name'

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -33,6 +33,13 @@ module Hubstats
        .joins(sanitize_sql_array(["LEFT JOIN hubstats_comments ON hubstats_comments.user_id = hubstats_users.id AND (hubstats_comments.created_at BETWEEN ? AND ?)", start_date, end_date]))
        .group("hubstats_users.id")
     }
+
+    scope :qa_signoffs_count, lambda {|start_date, end_date|
+      select("hubstats_users.id as user_id")
+       .select("IFNULL(COUNT(DISTINCT hubstats_qa_signoffs.id),0) AS qa_signoff_count")
+       .joins(sanitize_sql_array(["LEFT JOIN hubstats_qa_signoffs ON hubstats_qa_signoffs.user_id = hubstats_users.id AND (hubstats_qa_signoffs.signed_at BETWEEN ? AND ?)", start_date, end_date]))
+       .group("hubstats_users.id")
+    }
  
     # Public - Counts all of the merged pull requests for selected user that occurred between the start_date and end_date.
     # 
@@ -52,11 +59,12 @@ module Hubstats
     # start_date - the start of the date range
     # end_date - the end of the data range
     #
-    # Returns - the count of deploys, pull requests, and comments
+    # Returns - the count of deploys, pull requests, QA Signoffs, and comments
     scope :pull_comment_deploy_count, lambda {|start_date, end_date|
-      select("hubstats_users.*, pull_request_count, comment_count, deploy_count")
+      select("hubstats_users.*, pull_request_count, comment_count, qa_signoff_count, deploy_count")
       .joins("LEFT JOIN (#{pull_requests_count(start_date, end_date).to_sql}) AS pull_requests ON pull_requests.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{comments_count(start_date, end_date).to_sql}) AS comments ON comments.user_id = hubstats_users.id")
+      .joins("LEFT JOIN (#{qa_signoffs_count(start_date, end_date).to_sql}) AS qa_signoffs ON qa_signoffs.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{deploys_count(start_date, end_date).to_sql}) AS deploys ON deploys.user_id = hubstats_users.id")
       .group("hubstats_users.id")
     }
@@ -87,6 +95,13 @@ module Hubstats
       .group("hubstats_users.id")
     }
 
+    scope :qa_signoffs_count_by_repo, lambda {|start_date, end_date, repo_id|
+      select("hubstats_users.id as user_id")
+      .select("COUNT(DISTINCT hubstats_qa_signoffs.id) AS qa_signoff_count")
+      .joins(sanitize_sql_array(["LEFT JOIN hubstats_qa_signoffs ON hubstats_qa_signoffs.user_id = hubstats_users.id AND (hubstats_qa_signoffs.signed_at BETWEEN ? AND ?) AND (hubstats_qa_signoffs.repo_id LIKE ?)", start_date, end_date, repo_id]))
+      .group("hubstats_users.id")
+    }
+
     # Public - Counts all of the pull requests for selected user that occurred between the start_date and end_date and belong to the repos.
     # 
     # start_date - the start of the date range
@@ -106,11 +121,12 @@ module Hubstats
     # start_date - the start of the date range
     # end_date - the end of the data range
     #
-    # Returns - the count of deploys, pull requests, and comments
+    # Returns - the count of deploys, pull requests, QA Signoffs, and comments
     scope :pull_comment_deploy_count_by_repo, lambda {|start_date, end_date, repo_id|
       select("hubstats_users.*, pull_request_count, comment_count, deploy_count")
       .joins("LEFT JOIN (#{pull_requests_count_by_repo(start_date, end_date, repo_id).to_sql}) AS pull_requests ON pull_requests.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{comments_count_by_repo(start_date, end_date, repo_id).to_sql}) AS comments ON comments.user_id = hubstats_users.id")
+      .joins("LEFT JOIN (#{qa_signoffs_count_by_repo(start_date, end_date, repo_id).to_sql}) AS qa_signoffs ON qa_signoffs.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{deploys_count_by_repo(start_date, end_date, repo_id).to_sql}) AS deploys ON deploys.user_id = hubstats_users.id")
       .group("hubstats_users.id")
     }
@@ -138,10 +154,11 @@ module Hubstats
     # 
     # Returns - all of the stats about the user
     scope :with_all_metrics_repos, lambda {|start_date, end_date, repos|
-      select("hubstats_users.*, deploy_count, pull_request_count, comment_count, additions, deletions")
+      select("hubstats_users.*, deploy_count, pull_request_count, comment_count, qa_signoff_count, additions, deletions")
       .joins("LEFT JOIN (#{net_additions_count(start_date, end_date).to_sql}) AS net_additions ON net_additions.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{pull_requests_count_by_repo(start_date, end_date, repos).to_sql}) AS pull_requests ON pull_requests.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{comments_count_by_repo(start_date, end_date, repos).to_sql}) AS comments ON comments.user_id = hubstats_users.id")
+      .joins("LEFT JOIN (#{qa_signoffs_count_by_repo(start_date, end_date, repos).to_sql} AS qa_signoffs ON qa_signoffs.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{deploys_count_by_repo(start_date, end_date, repos).to_sql}) AS deploys ON deploys.user_id = hubstats_users.id")
       .group("hubstats_users.id")
     }
@@ -157,6 +174,7 @@ module Hubstats
       .joins("LEFT JOIN (#{net_additions_count(start_date, end_date).to_sql}) AS net_additions ON net_additions.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{pull_requests_count(start_date, end_date).to_sql}) AS pull_requests ON pull_requests.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{comments_count(start_date, end_date).to_sql}) AS comments ON comments.user_id = hubstats_users.id")
+      .joins("LEFT JOIN (#{qa_signoffs_count(start_date, end_date).to_sql}) AS qa_signoffs ON qa_signoffs.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{deploys_count(start_date, end_date).to_sql}) AS deploys ON deploys.user_id = hubstats_users.id")
       .group("hubstats_users.id")
     }

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -35,6 +35,12 @@ module Hubstats
        .group("hubstats_users.id")
     }
 
+    # Public - Counts all of the QA Signoffs for selected user that were signed between the start_date and end_date.
+    # 
+    # start_date - the start of the date range
+    # end_date - the end of the data range
+    # 
+    # Returns - count of QA Signoffs
     scope :qa_signoffs_count, lambda {|start_date, end_date|
       select("hubstats_users.id as user_id")
        .select("IFNULL(COUNT(DISTINCT hubstats_qa_signoffs.id),0) AS qa_signoff_count")
@@ -55,7 +61,7 @@ module Hubstats
       .group("hubstats_users.id")
     }
 
-    # Public - Counts all of the merged pull requests, deploys, and comments that occurred between the start_date and end_date that belong to a user.
+    # Public - Counts all of the merged pull requests, deploys, QA Signoffs, and comments that occurred between the start_date and end_date that belong to a user.
     #
     # start_date - the start of the date range
     # end_date - the end of the data range
@@ -96,6 +102,12 @@ module Hubstats
       .group("hubstats_users.id")
     }
 
+    # Public - Counts all of the QA Signoffs for selected user that were signed between the start_date and end_date and belong to the repos.
+    # 
+    # start_date - the start of the date range
+    # end_date - the end of the data range
+    # 
+    # Returns - count of QA Signoffs
     scope :qa_signoffs_count_by_repo, lambda {|start_date, end_date, repo_id|
       select("hubstats_users.id as user_id")
       .select("COUNT(DISTINCT hubstats_qa_signoffs.id) AS qa_signoff_count")
@@ -116,7 +128,7 @@ module Hubstats
       .group("hubstats_users.id")
     }
 
-    # Public - Counts all of the merged pull requests, deploys, and comments that belong to a repository and belong to a user and occurred between 
+    # Public - Counts all of the merged pull requests, deploys, QA Signoffs and comments that belong to a repository and belong to a user and occurred between 
     # the start_date and end_date.
     #
     # start_date - the start of the date range
@@ -147,7 +159,7 @@ module Hubstats
       .group("hubstats_users.id")
     }
 
-    # Public - Joins all of the metrics together for selected repository: average additions and deletions, comments, pull requests, and deploys.
+    # Public - Joins all of the metrics together for selected repository: average additions and deletions, comments, pull requests, QA Signoffs and deploys.
     # However, will only count those that also have something to do with the repos passed in.
     # 
     # start_date - the start of the date range
@@ -164,7 +176,7 @@ module Hubstats
       .group("hubstats_users.id")
     }
 
-    # Public - Joins all of the metrics together for selected user: average additions and deletions, comments, pull requests, and deploys.
+    # Public - Joins all of the metrics together for selected user: average additions and deletions, comments, pull requests, QA Signoffs and deploys.
     # 
     # start_date - the start of the date range
     # end_date - the end of the data range

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -123,7 +123,7 @@ module Hubstats
     #
     # Returns - the count of deploys, pull requests, QA Signoffs, and comments
     scope :pull_comment_deploy_count_by_repo, lambda {|start_date, end_date, repo_id|
-      select("hubstats_users.*, pull_request_count, comment_count, deploy_count")
+      select("hubstats_users.*, pull_request_count, comment_count, qa_signoff_count, deploy_count")
       .joins("LEFT JOIN (#{pull_requests_count_by_repo(start_date, end_date, repo_id).to_sql}) AS pull_requests ON pull_requests.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{comments_count_by_repo(start_date, end_date, repo_id).to_sql}) AS comments ON comments.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{qa_signoffs_count_by_repo(start_date, end_date, repo_id).to_sql}) AS qa_signoffs ON qa_signoffs.user_id = hubstats_users.id")
@@ -170,7 +170,7 @@ module Hubstats
     # 
     # Returns - all of the stats about the user
     scope :with_all_metrics, lambda {|start_date, end_date|
-      select("hubstats_users.*, deploy_count, pull_request_count, comment_count, additions, deletions")
+      select("hubstats_users.*, deploy_count, pull_request_count, comment_count, qa_signoff_count, additions, deletions")
       .joins("LEFT JOIN (#{net_additions_count(start_date, end_date).to_sql}) AS net_additions ON net_additions.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{pull_requests_count(start_date, end_date).to_sql}) AS pull_requests ON pull_requests.user_id = hubstats_users.id")
       .joins("LEFT JOIN (#{comments_count(start_date, end_date).to_sql}) AS comments ON comments.user_id = hubstats_users.id")

--- a/app/views/hubstats/partials/_quick_stats_one.html.erb
+++ b/app/views/hubstats/partials/_quick_stats_one.html.erb
@@ -43,6 +43,12 @@
     <h4> Comments </h4>
   </div>
 <% end %>
+<% if @stats_row_one.has_key? :qa_signoff_count %>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1><%= @stats_row_one[:qa_signoff_count] %> </h1>
+    <h4> QA Signoffs </h4>
+  </div>
+<% end %>
 <% if @stats_row_one.has_key? :review_count %>
   <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
      <h1> <%= @stats_row_one[:review_count] %> </h1>

--- a/app/views/hubstats/partials/_quick_stats_two.html.erb
+++ b/app/views/hubstats/partials/_quick_stats_two.html.erb
@@ -43,6 +43,12 @@
     <h4> Comments </h4>
   </div>
 <% end %>
+<% if @stats_row_two.has_key? :qa_signoff_count %>
+  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
+    <h1><%= @stats_row_one[:qa_signoff_count] %> </h1>
+    <h4> QA Signoffs </h4>
+  </div>
+<% end %>
 <% if @stats_row_two.has_key? :review_count %>
   <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
      <h1> <%= @stats_row_two[:review_count] %> </h1>

--- a/app/views/hubstats/partials/_user.html.erb
+++ b/app/views/hubstats/partials/_user.html.erb
@@ -4,7 +4,7 @@
   <div class="user-image col-lg-1 col-md-1 col-sm-1" >
     <img src= <%= user.avatar_url%> alt= <%= user.login %> >
   </div>
-  <div class="user-info col-lg-3 col-md-3 col-sm-3">
+  <div class="user-info col-lg-4 col-md-4 col-sm-4">
     <h4> 
       <%= link_to user.login, user_path(user) %>
     </h4>
@@ -19,7 +19,7 @@
   </div>
 
   <!-- Show the basic stats for this user for this user -->
-  <div class="col-lg-2 col-md-2 col-sm-2">
+  <div class="col-lg-1 col-md-1 col-sm-1">
     <div class="text-center">
       <span class="text-large"><%= user.deploy_count %></span>
       <span class="mega-octicon octicon-rocket"></span>
@@ -31,7 +31,7 @@
       <span class="mega-octicon octicon-git-pull-request"></span>
     </div>
   </div>
-  <div class="col-lg-2 col-md-2 col-sm-2">
+  <div class="col-lg-1 col-md-1 col-sm-1">
     <div class="text-center">
       <span class="text-large"><%= user.comment_count %></span>
       <span class="mega-octicon octicon-comment"></span>
@@ -39,7 +39,15 @@
   </div>
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
+      <span class="text-large"><%= user.qa_signoff_count %></span>
+      <span class="mega-octicon octicon-checklist"></span>
+    </div>
+  </div>
+
+  <div class="col-lg-1 col-md-1 col-sm-1">
+    <div class="text-center">
       <span class="text-large"><%= user.additions - user.deletions %></span>
+      <span class="mega-octicon octicon-diff"></span>
     </div>
   </div>
 </div>

--- a/app/views/hubstats/partials/_user.html.erb
+++ b/app/views/hubstats/partials/_user.html.erb
@@ -31,7 +31,7 @@
       <span class="mega-octicon octicon-git-pull-request"></span>
     </div>
   </div>
-  <div class="col-lg-1 col-md-1 col-sm-1">
+  <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= user.comment_count %></span>
       <span class="mega-octicon octicon-comment"></span>
@@ -44,10 +44,9 @@
     </div>
   </div>
 
-  <div class="col-lg-2 col-md-2 col-sm-2">
+  <div class="col-lg-1 col-md-1 col-sm-1">
     <div class="text-center">
       <span class="text-large"><%= user.additions - user.deletions %></span>
-      <span class="mega-octicon octicon-diff"></span>
     </div>
   </div>
 </div>

--- a/app/views/hubstats/partials/_user.html.erb
+++ b/app/views/hubstats/partials/_user.html.erb
@@ -4,7 +4,7 @@
   <div class="user-image col-lg-1 col-md-1 col-sm-1" >
     <img src= <%= user.avatar_url%> alt= <%= user.login %> >
   </div>
-  <div class="user-info col-lg-4 col-md-4 col-sm-4">
+  <div class="user-info col-lg-2 col-md-2 col-sm-2">
     <h4> 
       <%= link_to user.login, user_path(user) %>
     </h4>
@@ -19,7 +19,7 @@
   </div>
 
   <!-- Show the basic stats for this user for this user -->
-  <div class="col-lg-1 col-md-1 col-sm-1">
+  <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= user.deploy_count %></span>
       <span class="mega-octicon octicon-rocket"></span>
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <div class="col-lg-1 col-md-1 col-sm-1">
+  <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= user.additions - user.deletions %></span>
       <span class="mega-octicon octicon-diff"></span>

--- a/app/views/hubstats/tables/_users.html.erb
+++ b/app/views/hubstats/tables/_users.html.erb
@@ -2,10 +2,10 @@
 <% if @users.length > 0 %>
   <div class="users">
     <div class="row single-user header">
-      <div class="col-lg-5 col-md-5 col-sm-5">
+      <div class="col-lg-3 col-md-3 col-sm-3">
         <a class="header desc" id="name"> GitHub Username <span class="octicon"></span> </a>
       </div>
-      <div class="col-lg-1 col-md-1 col-sm-1">
+      <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="deploys"> Deployments <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
@@ -17,7 +17,7 @@
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="signoffs"> QA Signoffs <span class="octicon"></span></a>
       </div>
-      <div class="col-lg-1 col-md-1 col-sm-1">
+      <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="netadditions"> Net Additions <span class="octicon"></span></a>
       </div>
     </div>

--- a/app/views/hubstats/tables/_users.html.erb
+++ b/app/views/hubstats/tables/_users.html.erb
@@ -11,13 +11,13 @@
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>
-      <div class="col-lg-1 col-md-1 col-sm-1">
+      <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="comments"> Comments <span class="octicon"></span></a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="signoffs"> QA Signoffs <span class="octicon"></span></a>
       </div>
-      <div class="col-lg-2 col-md-2 col-sm-2">
+      <div class="col-lg-1 col-md-1 col-sm-1">
         <a class="header desc" id="netadditions"> Net Additions <span class="octicon"></span></a>
       </div>
     </div>

--- a/app/views/hubstats/tables/_users.html.erb
+++ b/app/views/hubstats/tables/_users.html.erb
@@ -2,19 +2,22 @@
 <% if @users.length > 0 %>
   <div class="users">
     <div class="row single-user header">
-      <div class="col-lg-4 col-md-4 col-sm-4">
+      <div class="col-lg-5 col-md-5 col-sm-5">
         <a class="header desc" id="name"> GitHub Username <span class="octicon"></span> </a>
       </div>
-      <div class="col-lg-2 col-md-2 col-sm-2">
+      <div class="col-lg-1 col-md-1 col-sm-1">
         <a class="header desc" id="deploys"> Deployments <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>
-      <div class="col-lg-2 col-md-2 col-sm-2">
+      <div class="col-lg-1 col-md-1 col-sm-1">
         <a class="header desc" id="comments"> Comments <span class="octicon"></span></a>
       </div>
       <div class="col-lg-2 col-md-2 col-sm-2">
+        <a class="header desc" id="signoffs"> QA Signoffs <span class="octicon"></span></a>
+      </div>
+      <div class="col-lg-1 col-md-1 col-sm-1">
         <a class="header desc" id="netadditions"> Net Additions <span class="octicon"></span></a>
       </div>
     </div>

--- a/app/views/hubstats/users/show.html.erb
+++ b/app/views/hubstats/users/show.html.erb
@@ -25,8 +25,6 @@
     <%= render 'hubstats/partials/quick_stats_two' %>
   </div>
 
-  QA Signoffs: <% Hubstats::QaSignoff.belonging_to_user(@user.id).first.label_name %>
-
   <div class="row">
 
     <!-- Show all of this user's merged pull requests in a "condensed" view -->

--- a/app/views/hubstats/users/show.html.erb
+++ b/app/views/hubstats/users/show.html.erb
@@ -14,8 +14,18 @@
     </h4>
 
     <!-- Show all of the stats about the user -->
-    <%= render 'hubstats/partials/quick_stats_one' %>
+
+    <%= render 'hubstats/partials/quick_stats_one' %>    
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <%= render 'hubstats/partials/quick_stats_two' %>
   </div>
+
+  QA Signoffs: <% Hubstats::QaSignoff.belonging_to_user(@user.id).first.label_name %>
 
   <div class="row">
 

--- a/db/migrate/20161215163228_add_qa_signoff.rb
+++ b/db/migrate/20161215163228_add_qa_signoff.rb
@@ -1,0 +1,14 @@
+class AddQaSignoff < ActiveRecord::Migration
+  def change
+    create_table :hubstats_qa_signoffs do |t|
+      t.belongs_to :user
+      t.belongs_to :repo
+      t.belongs_to :pull_request
+      t.string :label_name
+    end
+
+    add_index :hubstats_qa_signoffs, :user_id
+    add_index :hubstats_qa_signoffs, :repo_id
+    add_index :hubstats_qa_signoffs, :pull_request_id
+  end
+end

--- a/db/migrate/20161215193059_signed_column_for_signoff.rb
+++ b/db/migrate/20161215193059_signed_column_for_signoff.rb
@@ -1,0 +1,5 @@
+class SignedColumnForSignoff < ActiveRecord::Migration
+  def change
+  	add_column :hubstats_qa_signoffs, :signed_at, :datetime
+  end
+end

--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -32,6 +32,9 @@ module Hubstats
       pull_request[:repository] = payload[:repository]
       new_pull = Hubstats::PullRequest.create_or_update(pull_request.with_indifferent_access)
       if payload[:action].include?('labeled')
+        if payload[:label][:name].include?('qa-approved')
+          Hubstats::QaSignoff.first_or_create(payload[:repository][:id], payload[:pull_request][:id], payload[:sender][:id])
+        end
         new_pull.update_label(payload)
       else
         repo_name = Hubstats::Repo.where(id: new_pull.repo_id).first.full_name

--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -31,14 +31,14 @@ module Hubstats
       pull_request = payload[:pull_request]
       pull_request[:repository] = payload[:repository]
       new_pull = Hubstats::PullRequest.create_or_update(pull_request.with_indifferent_access)
-      Rails.logger.warn "Processing as a pull request."
-      if payload[:action].include?('labeled')
-        Rails.logger.warn "We are labeling something"
-        if payload[:action].include?('unlabeled') && payload[:label][:name].include?('qa-approved')
-          Rails.logger.warn "We are removing a qa-approved label"
+      # Rails.logger.warn "Processing as a pull request."
+      if payload[:github_action].include?('labeled')
+        # Rails.logger.warn "We are labeling something"
+        if payload[:github_action].include?('unlabeled') && payload[:label][:name].include?('qa-approved')
+          # Rails.logger.warn "We are removing a qa-approved label"
           Hubstats::QaSignoff.remove_signoff(payload[:repository][:id], payload[:pull_request][:id])
         elsif payload[:label][:name].include?('qa-approved')
-          Rails.logger.warn "We are adding a qa-approved label"
+          # Rails.logger.warn "We are adding a qa-approved label"
           Hubstats::QaSignoff.first_or_create(payload[:repository][:id], payload[:pull_request][:id], payload[:sender][:id])
         end
         Rails.logger.warn "Updating label"

--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -22,7 +22,8 @@ module Hubstats
       end
     end
 
-    # Public - Gets the information for the PR, creates/updates the new PR, grabs the labels, and makes new labels
+    # Public - Gets the information for the PR, creates/updates the new PR, grabs the labels, and makes new labels;
+    #  if the label qa-approved is added or removed, a new QA Signoff record will be made
     #
     # payload - the information that we will use to get data off of
     #
@@ -31,17 +32,12 @@ module Hubstats
       pull_request = payload[:pull_request]
       pull_request[:repository] = payload[:repository]
       new_pull = Hubstats::PullRequest.create_or_update(pull_request.with_indifferent_access)
-      # Rails.logger.warn "Processing as a pull request."
       if payload[:github_action].include?('labeled')
-        # Rails.logger.warn "We are labeling something"
         if payload[:github_action].include?('unlabeled') && payload[:label][:name].include?('qa-approved')
-          # Rails.logger.warn "We are removing a qa-approved label"
           Hubstats::QaSignoff.remove_signoff(payload[:repository][:id], payload[:pull_request][:id])
         elsif payload[:label][:name].include?('qa-approved')
-          # Rails.logger.warn "We are adding a qa-approved label"
           Hubstats::QaSignoff.first_or_create(payload[:repository][:id], payload[:pull_request][:id], payload[:sender][:id])
         end
-        Rails.logger.warn "Updating label"
         new_pull.update_label(payload)
       else
         repo_name = Hubstats::Repo.where(id: new_pull.repo_id).first.full_name

--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -31,12 +31,17 @@ module Hubstats
       pull_request = payload[:pull_request]
       pull_request[:repository] = payload[:repository]
       new_pull = Hubstats::PullRequest.create_or_update(pull_request.with_indifferent_access)
+      Rails.logger.warn "Processing as a pull request."
       if payload[:action].include?('labeled')
+        Rails.logger.warn "We are labeling something"
         if payload[:action].include?('unlabeled') && payload[:label][:name].include?('qa-approved')
+          Rails.logger.warn "We are removing a qa-approved label"
           Hubstats::QaSignoff.remove_signoff(payload[:repository][:id], payload[:pull_request][:id])
         elsif payload[:label][:name].include?('qa-approved')
+          Rails.logger.warn "We are adding a qa-approved label"
           Hubstats::QaSignoff.first_or_create(payload[:repository][:id], payload[:pull_request][:id], payload[:sender][:id])
         end
+        Rails.logger.warn "Updating label"
         new_pull.update_label(payload)
       else
         repo_name = Hubstats::Repo.where(id: new_pull.repo_id).first.full_name

--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -32,7 +32,9 @@ module Hubstats
       pull_request[:repository] = payload[:repository]
       new_pull = Hubstats::PullRequest.create_or_update(pull_request.with_indifferent_access)
       if payload[:action].include?('labeled')
-        if payload[:label][:name].include?('qa-approved')
+        if payload[:action].include?('unlabeled') && payload[:label][:name].include?('qa-approved')
+          Hubstats::QaSignoff.remove_signoff(payload[:repository][:id], payload[:pull_request][:id])
+        elsif payload[:label][:name].include?('qa-approved')
           Hubstats::QaSignoff.first_or_create(payload[:repository][:id], payload[:pull_request][:id], payload[:sender][:id])
         end
         new_pull.update_label(payload)

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -15,6 +15,7 @@ module Hubstats
       end
 
       it 'should add labels to pull request' do
+        payload[:github_action] = 'created'
         allow(PullRequest).to receive(:create_or_update) {pull}
         allow(Repo).to receive(:where) {[repo,repo]}
         allow(GithubAPI).to receive(:get_labels_for_pull) {[{name: 'low'}, {name: 'high'}]}
@@ -23,7 +24,7 @@ module Hubstats
       end
 
       it 'should add new labels to pull requests' do
-        payload[:action] = 'labeled'
+        payload[:github_action] = 'labeled'
         payload[:label] = {name: 'new_label'}
         allow(PullRequest).to receive(:create_or_update) {pull}
         allow(Repo).to receive(:where) {[repo,repo]}
@@ -33,7 +34,7 @@ module Hubstats
       end
 
       it 'should remove old labels from pull requests' do
-        payload[:action] = 'unlabeled'
+        payload[:github_action] = 'unlabeled'
         payload[:label] = {name: 'old_label'}
         allow(PullRequest).to receive(:create_or_update) {pull}
         allow(Repo).to receive(:where) {[repo,repo]}

--- a/spec/models/hubstats/qa_signoff_spec.rb
+++ b/spec/models/hubstats/qa_signoff_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+module Hubstats
+  describe QaSignoff, :type => :model do
+    it 'should create and return a QA Signoff' do
+      signoff = QaSignoff.first_or_create(123, 456, 789)
+      expect(signoff.user_id).to eq(789)
+      expect(signoff.repo_id).to eq(123)
+      expect(signoff.pull_request_id).to eq(456)
+    end
+
+    it 'should remove a signoff' do
+      signoff = QaSignoff.first_or_create(123, 456, 789)
+      expect(Hubstats::QaSignoff.where(pull_request_id: 456).count).to eq(1)
+      QaSignoff.remove_signoff(123, 456)
+      expect(Hubstats::QaSignoff.where(pull_request_id: 456)).to eq([])
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,14 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160113182419) do
+ActiveRecord::Schema.define(version: 20161215193314) do
 
   create_table "hubstats_comments", force: :cascade do |t|
     t.string   "html_url",         limit: 255
     t.string   "url",              limit: 255
     t.string   "pull_request_url", limit: 255
     t.integer  "path",             limit: 4
-    t.string   "body_string",      limit: 255
     t.string   "kind",             limit: 255
     t.integer  "user_id",          limit: 4
     t.integer  "pull_request_id",  limit: 4
@@ -81,6 +80,18 @@ ActiveRecord::Schema.define(version: 20160113182419) do
   add_index "hubstats_pull_requests", ["repo_id"], name: "index_hubstats_pull_requests_on_repo_id", using: :btree
   add_index "hubstats_pull_requests", ["team_id"], name: "index_hubstats_pull_requests_on_team_id", using: :btree
   add_index "hubstats_pull_requests", ["user_id"], name: "index_hubstats_pull_requests_on_user_id", using: :btree
+
+  create_table "hubstats_qa_signoffs", force: :cascade do |t|
+    t.integer  "user_id",         limit: 4
+    t.integer  "repo_id",         limit: 4
+    t.integer  "pull_request_id", limit: 4
+    t.string   "label_name",      limit: 255
+    t.datetime "signed_at"
+  end
+
+  add_index "hubstats_qa_signoffs", ["pull_request_id"], name: "index_hubstats_qa_signoffs_on_pull_request_id", using: :btree
+  add_index "hubstats_qa_signoffs", ["repo_id"], name: "index_hubstats_qa_signoffs_on_repo_id", using: :btree
+  add_index "hubstats_qa_signoffs", ["user_id"], name: "index_hubstats_qa_signoffs_on_user_id", using: :btree
 
   create_table "hubstats_repos", force: :cascade do |t|
     t.string   "name",       limit: 255


### PR DESCRIPTION
Description and Impact
----------------------
On the page that lists all of the users, there should be a new column that lists the amount of QA Signoffs a user has completed. A QA Signoff is a label that is applied to every PR before we deploy it to Production. Therefore, Hubstats must read the new labels as they come in, determine if it is a QA Signoff (if the label is `qa-approved`), and add it to the table of QA Signoffs. Then, not only will it be added to the list of counts of QA Signoffs, but it will also reflect this count on the users' show pages in the top stats of each user.

Deploy Plan
-----------
There are migrations in this PR.

* `git checkout master`
* `op accept-pull 110`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Check that Hubstats is showing a place for QA Signoffs in both the user's index page and show page and that number reflects proper data in database table
- [x] Check that Hubstats is reading webhooks correctly and gathering a list of QA Signoffs