### PR TITLE
Do not show ignored users on lists, in stats, etc

### DIFF
--- a/app/controllers/hubstats/users_controller.rb
+++ b/app/controllers/hubstats/users_controller.rb
@@ -14,6 +14,7 @@ module Hubstats
         @users = Hubstats::User.where(id: params[:id].split(",")).order("login ASC")
       else
         @users = Hubstats::User.with_all_metrics(@start_date, @end_date)
+          .where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"])
           .with_id(params[:users])
           .custom_order(params[:order])
           .paginate(:page => params[:page], :per_page => 15)

--- a/app/helpers/hubstats/metrics_helper.rb
+++ b/app/helpers/hubstats/metrics_helper.rb
@@ -26,14 +26,14 @@ module Hubstats
     #
     # Returns - the number of pull requests
     def get_pull_count
-      Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).count(:all)
+      Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).ignore_pulls_by(Hubstats::User.ignore_users_ids).count(:all)
     end
 
     # Public - Gets the number of comments within the start date and end date
     #
     # Returns - the number of comments
     def get_comment_count
-      Hubstats::Comment.created_in_date_range(@start_date, @end_date).count(:all)
+      Hubstats::Comment.created_in_date_range(@start_date, @end_date).ignore_comments_by(Hubstats::User.ignore_users_ids).count(:all)
     end
 
     # Public - Gets the number of comments per reviewer within the start date and end date

--- a/app/models/hubstats/comment.rb
+++ b/app/models/hubstats/comment.rb
@@ -5,6 +5,7 @@ module Hubstats
 
     # Various checks that can be used to filter and find info about comments.
     scope :created_in_date_range, lambda {|start_date, end_date| where("hubstats_comments.created_at BETWEEN ? AND ?", start_date, end_date)}
+    scope :ignore_comments_by, lambda {|user_ids| where("user_id NOT IN (?)", user_ids) if user_ids}
     scope :belonging_to_pull_request, lambda {|pull_request_id| where(pull_request_id: pull_request_id)}
     scope :belonging_to_user, lambda {|user_id| where(user_id: user_id)}
     scope :belonging_to_team, lambda {|user_ids| where(user_id: user_ids) if user_ids}

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -9,6 +9,7 @@ module Hubstats
     scope :created_in_date_range, lambda {|start_date, end_date| where("hubstats_pull_requests.created_at BETWEEN ? AND ?", start_date, end_date)}
     scope :merged_in_date_range, lambda {|start_date, end_date| where("hubstats_pull_requests.merged").where("hubstats_pull_requests.merged_at BETWEEN ? AND ?", start_date, end_date)}
     scope :created_since, lambda {|days| where("hubstats_pull_requests.created_at > ?", Date.today - days)}
+    scope :ignore_pulls_by, lambda {|user_ids| where("user_id NOT IN (?)", user_ids) if user_ids}
     scope :belonging_to_repo, lambda {|repo_id| where(repo_id: repo_id)}
     scope :belonging_to_team, lambda {|team_id| where(team_id: team_id)}
     scope :belonging_to_user, lambda {|user_id| where(user_id: user_id)}

--- a/app/models/hubstats/user.rb
+++ b/app/models/hubstats/user.rb
@@ -3,10 +3,11 @@ module Hubstats
 
     # Various checks that can be used to filter and find info about users.
     scope :with_id, lambda {|user_id| where(id: user_id.split(',')) if user_id}
-    scope :only_active, -> { having("comment_count > 0 OR pull_request_count > 0 OR deploy_count > 0") }
-    scope :is_developer, -> { having("pull_request_count > 0") }
-    scope :is_reviewer, -> { having("comment_count > 0") }
+    scope :only_active, -> { where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"]).having("comment_count > 0 OR pull_request_count > 0 OR deploy_count > 0") }
+    scope :is_developer, -> { where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"]).having("pull_request_count > 0") }
+    scope :is_reviewer, -> { where("login NOT IN (?)", Hubstats.config.github_config["ignore_users_list"]).having("comment_count > 0") }
     scope :with_contributions, lambda {|start_date, end_date, repo_id| with_all_metrics_repos(start_date, end_date, repo_id) if repo_id}
+    scope :ignore_users_ids, -> { where("login IN (?)", Hubstats.config.github_config["ignore_users_list"]).pluck(:id) }
 
     # Public - Counts all of the deploys for selected user that occurred between the start_date and end_date.
     # 

--- a/spec/controllers/hubstats/repos_controller_spec.rb
+++ b/spec/controllers/hubstats/repos_controller_spec.rb
@@ -22,6 +22,7 @@ module Hubstats
                               :name => "goosey",
                               :full_name => "sportngin/goosey",
                               :updated_at => Date.today)
+        allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("ignore_users_list") { ["user"] }
         get :index
         expect(assigns(:repos)).to contain_exactly(repo2, repo1, repo3, repo4)
       end
@@ -43,6 +44,7 @@ module Hubstats
                                       :user => user)
         deploy1 = create(:deploy, :repo_id => 101010)
         deploy2 = create(:deploy, :repo_id => 101010)
+        allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("ignore_users_list") { ["user"] }
         get :show, repo: repo.name
         expect(assigns(:repo)).to eq(repo)
         expect(assigns(:repo).pull_requests).to contain_exactly(pull1, pull2)
@@ -71,6 +73,7 @@ module Hubstats
                               :full_name => "sportngin/goosey",
                               :updated_at => Date.today)
         expect(Hubstats::Repo).to receive_message_chain("with_id.custom_order.paginate").and_return([repo1, repo2, repo3, repo4])
+        allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("ignore_users_list") { ["user"] }
         get :index
         expect(response).to have_http_status(200)
       end

--- a/spec/controllers/hubstats/users_controller_spec.rb
+++ b/spec/controllers/hubstats/users_controller_spec.rb
@@ -11,6 +11,7 @@ module Hubstats
         user3 = create(:user, :id => 303030, :login => "examplePerson3", :updated_at => Date.today)
         user4 = create(:user, :id => 404040, :login => "examplePerson4", :updated_at => Date.today)
         expect(Hubstats::User).to receive_message_chain("with_id.custom_order.paginate").and_return([user2, user3, user1, user4])
+        allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("ignore_users_list") { ["user"] }
         get :index
         expect(response).to have_http_status(200)
       end
@@ -26,6 +27,7 @@ module Hubstats
         deploy2 = create(:deploy, :user_id => 101010)
         comment1 = create(:comment, :user => user, :updated_at => Date.today)
         comment2 = create(:comment, :user => user, :updated_at => Date.today)
+        allow(Hubstats).to receive_message_chain(:config, :github_config, :[]).with("ignore_users_list") { ["user"] }
         get :show, id: "examplePerson"
         expect(assigns(:user)).to eq(user)
         expect(assigns(:user).pull_requests).to contain_exactly(pull1, pull2)


### PR DESCRIPTION
Description and Impact
----------------------
If a user is on the ignored_users_list, then their name should not show up in the list of users, nor should any comments/PRs made by them show up in the stats in the dashboard on the tops of the pages.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Go and see how many users are on the ignore-users-list (write them down)
- [x] Verify they're showing up on the list of users
- [x] Write down amount of comments/PRs
- [x] Put this new version out
- [x] Verify that the users are no longer on the list of users
- [x] The number of comments/PRs should be changed