### PR TITLE
The index between PR_ID and QA Signoff should be unique

### DIFF
--- a/db/migrate/20161222173310_make_qa_index_unique.rb
+++ b/db/migrate/20161222173310_make_qa_index_unique.rb
@@ -1,0 +1,6 @@
+class MakeQaIndexUnique < ActiveRecord::Migration
+  def change
+  	remove_index :hubstats_qa_signoffs, :pull_request_id
+  	add_index :hubstats_qa_signoffs, :pull_request_id, :unique => true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161215193314) do
+ActiveRecord::Schema.define(version: 20161222173633) do
 
   create_table "hubstats_comments", force: :cascade do |t|
     t.string   "html_url",         limit: 255
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 20161215193314) do
     t.datetime "signed_at"
   end
 
-  add_index "hubstats_qa_signoffs", ["pull_request_id"], name: "index_hubstats_qa_signoffs_on_pull_request_id", using: :btree
+  add_index "hubstats_qa_signoffs", ["pull_request_id"], name: "index_hubstats_qa_signoffs_on_pull_request_id", unique: true, using: :btree
   add_index "hubstats_qa_signoffs", ["repo_id"], name: "index_hubstats_qa_signoffs_on_repo_id", using: :btree
   add_index "hubstats_qa_signoffs", ["user_id"], name: "index_hubstats_qa_signoffs_on_user_id", using: :btree
 


### PR DESCRIPTION
Description and Impact
----------------------
The index between the QA Signoff and the PR id should be unique, so there will not be multiple QA Signoffs for one PR.

Deploy Plan
-----------
* `git checkout master`
* `git pull`
* `op accept-pull 112`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run the migrations and verify that there are no more duplicates