### PR TITLE
Fixing bugs where newly added labels are not appearing

### DIFF
--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -156,7 +156,6 @@ module Hubstats
     #
     # Returns - the new labels
     def add_labels(labels)
-      Rails.logger.warn "We are adding some labels"
       labels.map! { |label| Hubstats::Label.first_or_create(label) }
       self.labels = labels
     end
@@ -165,19 +164,13 @@ module Hubstats
     # @param payload Webhook
     # @return The list of labels after the update
     def update_label(payload)
-      Rails.logger.warn "We are updating some labels"
       return unless payload[:label]
-      Rails.logger.warn "We did not return; proceeding"
-      Rails.logger.warn "payload PR: #{payload[:pull_request][:title]}"
-      Rails.logger.warn "payload label: #{payload[:label][:name]}"
       label = Hubstats::Label.first_or_create(payload[:label])
       if payload[:github_action] == 'labeled'
-        Rails.logger.warn "We're adding the label to the list of labels"
         labels << label
       elsif payload[:github_action] == 'unlabeled'
         labels.delete(label)
       end
-      puts "Labels: #{labels}"
       labels
     end
   end

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -168,12 +168,16 @@ module Hubstats
       Rails.logger.warn "We are updating some labels"
       return unless payload[:label]
       Rails.logger.warn "We did not return; proceeding"
+      Rails.logger.warn "payload PR: #{payload[:pull_request][:title]}"
+      Rails.logger.warn "payload label: #{payload[:label][:name]}"
       label = Hubstats::Label.first_or_create(payload[:label])
       if payload[:action] == 'labeled'
+        Rails.logger.warn "We're adding the label to the list of labels"
         labels << label
       elsif payload[:action] == 'unlabeled'
         labels.delete(label)
       end
+      puts "Labels: #{labels}"
       labels
     end
   end

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -156,6 +156,7 @@ module Hubstats
     #
     # Returns - the new labels
     def add_labels(labels)
+      Rails.logger.warn "We are adding some labels"
       labels.map! { |label| Hubstats::Label.first_or_create(label) }
       self.labels = labels
     end
@@ -164,7 +165,9 @@ module Hubstats
     # @param payload Webhook
     # @return The list of labels after the update
     def update_label(payload)
+      Rails.logger.warn "We are updating some labels"
       return unless payload[:label]
+      Rails.logger.warn "We did not return; proceeding"
       label = Hubstats::Label.first_or_create(payload[:label])
       if payload[:action] == 'labeled'
         labels << label

--- a/app/models/hubstats/pull_request.rb
+++ b/app/models/hubstats/pull_request.rb
@@ -171,10 +171,10 @@ module Hubstats
       Rails.logger.warn "payload PR: #{payload[:pull_request][:title]}"
       Rails.logger.warn "payload label: #{payload[:label][:name]}"
       label = Hubstats::Label.first_or_create(payload[:label])
-      if payload[:action] == 'labeled'
+      if payload[:github_action] == 'labeled'
         Rails.logger.warn "We're adding the label to the list of labels"
         labels << label
-      elsif payload[:action] == 'unlabeled'
+      elsif payload[:github_action] == 'unlabeled'
         labels.delete(label)
       end
       puts "Labels: #{labels}"


### PR DESCRIPTION
Description and Impact
----------------------
Fixing bugs where new labels are not being correctly added and taken away from preexisting PRs. This also fixes a bug where sometimes duplicates of QA Signoffs show up in the database. Now, we make sure to delete all QA Signoffs when one is removed, and only create a new one if there aren't any already in the database.

Deploy Plan
-----------
* `git checkout master`
* `git pull`
* `op accept-pull 113`
* `soyuz deploy` with a patch level

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Try adding a label to a PR
- [x] Verify it shows up
- [x] Take away the label
- [x] Verify it goes away
