### PR TITLE
Fix bug where QA Signoffs appear twice for each signoff

### DIFF
--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -18,7 +18,7 @@ module Hubstats
 
     belongs_to :user
     belongs_to :repo
-    belongs_to :pull_request, :uniq => true
+    belongs_to :pull_request
 
     # Public - Makes a new QA Signoff with the data that is passed in.
     #

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -27,9 +27,13 @@ module Hubstats
     # user_id - the id of the user who added the label
     #
     # Returns - the QA Signoff
-    def self.first_or_create(repo_id, pr_id, user_id)
+    def self.first_or_create(repo_id, pr_id, user_id, paylaod)
       existing = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id)
       if existing.empty?
+        Rails.logger.warn "!!!!!!!! We will make a new QA Signoff"
+        Rails.logger.warn "Payload action: #{paylaod[:github_action]}"
+        Rails.logger.warn "Payload PR #: #{payload[:number]}"
+        Rails.logger.warn "Time: #{Time.now.getutc}"
         QaSignoff.create(user_id: user_id,
                          repo_id: repo_id,
                          pull_request_id: pr_id,

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -2,6 +2,7 @@ module Hubstats
   class QaSignoff < ActiveRecord::Base
 
     def self.record_timestamps; false; end
+    validates_uniqueness_of :pull_request_id
     
     # Various checks that can be used to filter, sort, and find info about QA Signoffs.
     scope :signed_within_date_range, lambda {|start_date, end_date| where("hubstats_qa_signoffs.signed_at BETWEEN ? AND ?", start_date, end_date)}

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -18,7 +18,7 @@ module Hubstats
 
     belongs_to :user
     belongs_to :repo
-    belongs_to :pull_request
+    belongs_to :pull_request, :uniq => true
 
     # Public - Makes a new QA Signoff with the data that is passed in.
     #
@@ -28,11 +28,14 @@ module Hubstats
     #
     # Returns - the QA Signoff
     def self.first_or_create(repo_id, pr_id, user_id)
-      QaSignoff.create(user_id: user_id,
-                       repo_id: repo_id,
-                       pull_request_id: pr_id,
-                       label_name: 'qa-approved',
-                       signed_at: Time.now.getutc)
+      existing = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id)
+      if existing.empty?
+        QaSignoff.create(user_id: user_id,
+                         repo_id: repo_id,
+                         pull_request_id: pr_id,
+                         label_name: 'qa-approved',
+                         signed_at: Time.now.getutc)
+      end
     end
 
     # Public - Deletes the QA Signoff of the PR that is passed in.
@@ -42,8 +45,10 @@ module Hubstats
     #
     # Returns - the deleted QA Signoff
     def self.remove_signoff(repo_id, pr_id)
-      signoff = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id).first
-      signoff.destroy if signoff
+      signoffs = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id)
+      signoffs.each do |signoff|
+        signoff.destroy if signoff
+      end
     end
   end
 end

--- a/app/models/hubstats/qa_signoff.rb
+++ b/app/models/hubstats/qa_signoff.rb
@@ -27,11 +27,11 @@ module Hubstats
     # user_id - the id of the user who added the label
     #
     # Returns - the QA Signoff
-    def self.first_or_create(repo_id, pr_id, user_id, paylaod)
+    def self.first_or_create(repo_id, pr_id, user_id, payload)
       existing = Hubstats::QaSignoff.where(repo_id: repo_id).where(pull_request_id: pr_id)
       if existing.empty?
         Rails.logger.warn "!!!!!!!! We will make a new QA Signoff"
-        Rails.logger.warn "Payload action: #{paylaod[:github_action]}"
+        Rails.logger.warn "Payload action: #{payload[:github_action]}"
         Rails.logger.warn "Payload PR #: #{payload[:number]}"
         Rails.logger.warn "Time: #{Time.now.getutc}"
         QaSignoff.create(user_id: user_id,

--- a/lib/hubstats/events_handler.rb
+++ b/lib/hubstats/events_handler.rb
@@ -36,7 +36,7 @@ module Hubstats
         if payload[:github_action].include?('unlabeled') && payload[:label][:name].include?('qa-approved')
           Hubstats::QaSignoff.remove_signoff(payload[:repository][:id], payload[:pull_request][:id])
         elsif payload[:label][:name].include?('qa-approved')
-          Hubstats::QaSignoff.first_or_create(payload[:repository][:id], payload[:pull_request][:id], payload[:sender][:id])
+          Hubstats::QaSignoff.first_or_create(payload[:repository][:id], payload[:pull_request][:id], payload[:sender][:id], payload)
         end
         new_pull.update_label(payload)
       else


### PR DESCRIPTION
Description and Impact
----------------------
Right now, many QA Signoffs are appearing twice in the database for each QA Signoff that actually happens. This should deploy a fix for that.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Look at database and check how many records are in there
- [ ] Add a QA Signoff
- [ ] Look at database again and verify that there is only one additional signoff for the QA Signoff
- [ ] Look at Hubstats; verify that the user's count has only gone up by one