### PR TITLE
Make helper namespace explicit to avoid conflicts

### DIFF
--- a/lib/hubstats/engine.rb
+++ b/lib/hubstats/engine.rb
@@ -10,7 +10,7 @@ module Hubstats
       Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").sort.each do |c|
         require_dependency(c)
       end
-      ApplicationController.helper(Hubstats::MetricsHelper)
+      ApplicationController.helper(::Hubstats::MetricsHelper)
     end
 
     require 'octokit'

--- a/lib/hubstats/engine.rb
+++ b/lib/hubstats/engine.rb
@@ -10,7 +10,7 @@ module Hubstats
       Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").sort.each do |c|
         require_dependency(c)
       end
-      ApplicationController.helper(MetricsHelper)
+      ApplicationController.helper(Hubstats::MetricsHelper)
     end
 
     require 'octokit'


### PR DESCRIPTION
What
----------------------
Use explicit namespace when including hubstats metrics helper.

Why
----------------------
To avoid conflicts.  If the consuming application has a `MetricsHelper` in the root namespace, it causes this to include the wrong module.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Verify engine loads up in a application and load a repos#index.

