### PR TITLE
Linking Today button in Hubstats datepicker

### DIFF
--- a/app/assets/javascripts/hubstats/application.js
+++ b/app/assets/javascripts/hubstats/application.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
   $('.input-daterange').datepicker({
     "todayHighlight": true,
     "endDate": "Today",
-    "todayBtn": true
+    "todayBtn": "linked"
   });
   setDateRange();
 });


### PR DESCRIPTION
Description and Impact
----------------------
This PR will "link" the datepicker so that it not only shows up and updates the month when selected, but will actually change the date in the datepicker.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Test out the Today button
- [x] Test out normal datepicker functionality