### PR TITLE
Hubstats does not need to show data for deployments

### DIFF
--- a/app/controllers/hubstats/repos_controller.rb
+++ b/app/controllers/hubstats/repos_controller.rb
@@ -37,6 +37,7 @@ module Hubstats
       @deploy_count = Hubstats::Deploy.belonging_to_repo(@repo.id).deployed_in_date_range(@start_date, @end_date).count(:all)
       @comment_count = Hubstats::Comment.belonging_to_repo(@repo.id).created_in_date_range(@start_date, @end_date).count(:all)
       @active_user_count = Hubstats::User.with_pulls_or_comments_or_deploys(@start_date, @end_date, @repo.id).only_active.length
+      @qa_signoff_count = Hubstats::QaSignoff.belonging_to_repo(@repo.id).signed_within_date_range(@start_date, @end_date).count(:all)
       @net_additions = Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_repo(@repo.id).sum(:additions).to_i -
                        Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_repo(@repo.id).sum(:deletions).to_i
       @additions = Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_repo(@repo.id).average(:additions)
@@ -53,9 +54,10 @@ module Hubstats
       @deletions ||= 0
       @stats_row_one = {
         active_user_count: @active_user_count,
-        deploy_count: @deploy_count,
+        # deploy_count: @deploy_count,
         pull_count: @pull_count,
-        comment_count: @comment_count
+        comment_count: @comment_count,
+        qa_signoff_count: @qa_signoff_count
       }
       @stats_row_two = {
         avg_additions: @additions.round.to_i,

--- a/app/controllers/hubstats/repos_controller.rb
+++ b/app/controllers/hubstats/repos_controller.rb
@@ -54,7 +54,6 @@ module Hubstats
       @deletions ||= 0
       @stats_row_one = {
         active_user_count: @active_user_count,
-        # deploy_count: @deploy_count,
         pull_count: @pull_count,
         comment_count: @comment_count,
         qa_signoff_count: @qa_signoff_count

--- a/app/controllers/hubstats/repos_controller.rb
+++ b/app/controllers/hubstats/repos_controller.rb
@@ -36,6 +36,7 @@ module Hubstats
       @deploys = Hubstats::Deploy.belonging_to_repo(@repo.id).deployed_in_date_range(@start_date, @end_date).order("deployed_at DESC").limit(20)
       @deploy_count = Hubstats::Deploy.belonging_to_repo(@repo.id).deployed_in_date_range(@start_date, @end_date).count(:all)
       @comment_count = Hubstats::Comment.belonging_to_repo(@repo.id).created_in_date_range(@start_date, @end_date).count(:all)
+      @users = Hubstats::User.with_pulls_or_comments_or_deploys(@start_date, @end_date, @repo.id).only_active.order("login ASC").limit(20)
       @active_user_count = Hubstats::User.with_pulls_or_comments_or_deploys(@start_date, @end_date, @repo.id).only_active.length
       @qa_signoff_count = Hubstats::QaSignoff.belonging_to_repo(@repo.id).signed_within_date_range(@start_date, @end_date).count(:all)
       @net_additions = Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_repo(@repo.id).sum(:additions).to_i -

--- a/app/controllers/hubstats/users_controller.rb
+++ b/app/controllers/hubstats/users_controller.rb
@@ -55,7 +55,6 @@ module Hubstats
       @deletions ||= 0
       @stats_row_one = {
         pull_count: @pull_count,
-        # deploy_count: @deploy_count,
         comment_count: @comment_count,
         qa_signoff_count: @qa_signoff_count
       }

--- a/app/controllers/hubstats/users_controller.rb
+++ b/app/controllers/hubstats/users_controller.rb
@@ -55,7 +55,7 @@ module Hubstats
       @deletions ||= 0
       @stats_row_one = {
         pull_count: @pull_count,
-        deploy_count: @deploy_count,
+        # deploy_count: @deploy_count,
         comment_count: @comment_count,
         qa_signoff_count: @qa_signoff_count
       }

--- a/app/helpers/hubstats/metrics_helper.rb
+++ b/app/helpers/hubstats/metrics_helper.rb
@@ -97,7 +97,6 @@ module Hubstats
         developer_count: get_developer_count,
         pull_count: get_pull_count,
         pulls_per_dev: get_pulls_per_dev,
-        # deploy_count: get_deploy_count,
         qa_signoff_count: get_qa_signoff_count,
         net_additions: get_net_additions
       }

--- a/app/helpers/hubstats/metrics_helper.rb
+++ b/app/helpers/hubstats/metrics_helper.rb
@@ -36,6 +36,13 @@ module Hubstats
       Hubstats::Comment.created_in_date_range(@start_date, @end_date).ignore_comments_by(Hubstats::User.ignore_users_ids).count(:all)
     end
 
+    # Public - Gets the number of QA signoffs within the start date and end date
+    #
+    # Returns - the number of QA signoffs
+    def get_qa_signoff_count
+      Hubstats::QaSignoff.signed_within_date_range(@start_date, @end_date).count(:all)
+    end
+
     # Public - Gets the number of comments per reviewer within the start date and end date
     #
     # Returns - the number of comments per reviewer
@@ -90,7 +97,8 @@ module Hubstats
         developer_count: get_developer_count,
         pull_count: get_pull_count,
         pulls_per_dev: get_pulls_per_dev,
-        deploy_count: get_deploy_count,
+        # deploy_count: get_deploy_count,
+        qa_signoff_count: get_qa_signoff_count,
         net_additions: get_net_additions
       }
       @stats_row_two = {

--- a/app/views/hubstats/partials/_header.html.erb
+++ b/app/views/hubstats/partials/_header.html.erb
@@ -23,8 +23,6 @@
             <%= link_to "Teams", teams_path%></li>
           <li class="<%='navbar-active' if params[:controller] == 'hubstats/users'%>">
             <%= link_to "Users", users_path%></li>
-          <li class="<%='navbar-active' if params[:controller] == 'hubstats/deploys'%>">
-            <%= link_to "Deployments", deploys_path%></li>
           <li class="<%='navbar-active' if params[:controller] == 'hubstats/pull_requests'%>">
             <%= link_to "Pull Requests", root_path%></li>
           <li>

--- a/app/views/hubstats/partials/_qa-signoff-condensed.html.erb
+++ b/app/views/hubstats/partials/_qa-signoff-condensed.html.erb
@@ -1,6 +1,6 @@
 <div class="row single-pull">
   <div class="user-image-small col-lg-1 col-md-1 col-sm-1 col-xs-2" >
-    <img src= <%= qa_signoff.user.avatar_url%> alt= <%= qa_signoff.user.login %> >
+    <img src= <%= qa_signoff.pull_request.user.avatar_url%> alt= <%= qa_signoff.pull_request.user.login %> >
   </div>
 
   <!-- Show the repo name and the specific qa_signoff request name and who made it when -->
@@ -9,7 +9,7 @@
       <%= link_to qa_signoff.repo.name, repo_path(qa_signoff.repo.name) %> /
       <%= link_to qa_signoff.pull_request.title, qa_signoff.pull_request.html_url, :target => '_blank' %>
     </h4>
-    by <%= link_to qa_signoff.user.login, user_path(qa_signoff.user) %>
+    by <%= link_to qa_signoff.pull_request.user.login, user_path(qa_signoff.pull_request.user) %>
     <% if qa_signoff.pull_request.merged == '1'%>
       <%= "merged #{time_ago_in_words(qa_signoff.pull_request.merged_at)} ago "%>
     <% elsif qa_signoff.pull_request.state == 'closed' %>

--- a/app/views/hubstats/partials/_qa-signoff-condensed.html.erb
+++ b/app/views/hubstats/partials/_qa-signoff-condensed.html.erb
@@ -1,10 +1,10 @@
-<div class="row single-qasignoff">
+<div class="row single-pull">
   <div class="user-image-small col-lg-1 col-md-1 col-sm-1 col-xs-2" >
     <img src= <%= qa_signoff.user.avatar_url%> alt= <%= qa_signoff.user.login %> >
   </div>
 
   <!-- Show the repo name and the specific qa_signoff request name and who made it when -->
-   <div class="qasignoff-info col-lg-9 col-md-9 col-sm-9 col-xs-8">
+  <div class="pull-info col-lg-9 col-md-9 col-sm-9 col-xs-8">
     <h4> 
       <%= link_to qa_signoff.repo.name, repo_path(qa_signoff.repo.name) %> /
       <%= link_to qa_signoff.pull_request.title, qa_signoff.pull_request.html_url, :target => '_blank' %>
@@ -21,7 +21,7 @@
 
   <!-- Show the pull request number and a link to the github PR -->
   <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2" >
-    <div class="qasignoff-right">
+    <div class="pull-right">
       <%= qa_signoff.pull_request.number %>
       <span class="octicon octicon-mark-github"></span>
       </span>

--- a/app/views/hubstats/partials/_quick_stats_one.html.erb
+++ b/app/views/hubstats/partials/_quick_stats_one.html.erb
@@ -31,12 +31,6 @@
     <h4> Pull Requests per Developer </h4>
   </div>
 <% end %>
-<% if @stats_row_one.has_key? :deploy_count %>
-  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-    <h1> <%= @stats_row_one[:deploy_count] %> </h1>
-    <h4> Deployments </h4>
-  </div>
-<% end %>
 <% if @stats_row_one.has_key? :comment_count %>
   <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
     <h1><%= @stats_row_one[:comment_count] %> </h1>

--- a/app/views/hubstats/partials/_quick_stats_two.html.erb
+++ b/app/views/hubstats/partials/_quick_stats_two.html.erb
@@ -31,12 +31,6 @@
     <h4> Pull Requests per Developer </h4>
   </div>
 <% end %>
-<% if @stats_row_two.has_key? :deploy_count %>
-  <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-    <h1> <%= @stats_row_two[:deploy_count] %> </h1>
-    <h4> Deployments </h4>
-  </div>
-<% end %>
 <% if @stats_row_two.has_key? :comment_count %>
   <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
     <h1><%= @stats_row_two[:comment_count] %> </h1>
@@ -45,7 +39,7 @@
 <% end %>
 <% if @stats_row_two.has_key? :qa_signoff_count %>
   <div class="col col-lg-2 col-md-3 col-sm-3 col-xs-3 text-center">
-    <h1><%= @stats_row_one[:qa_signoff_count] %> </h1>
+    <h1><%= @stats_row_two[:qa_signoff_count] %> </h1>
     <h4> QA Signoffs </h4>
   </div>
 <% end %>

--- a/app/views/hubstats/partials/_repo.html.erb
+++ b/app/views/hubstats/partials/_repo.html.erb
@@ -1,7 +1,7 @@
 <div class="row single-repo">
 
   <!-- Show the repo name and the date that it was last updated, with a link to the github repo -->
-  <div class="repo-info col-lg-2 col-md-2 col-sm-2 col-xs-8">
+  <div class="repo-info col-lg-4 col-md-4 col-sm-4 col-xs-8">
     <h4> 
       <%= link_to repo.name, repo_path(repo)%>
     </h4>
@@ -16,12 +16,12 @@
   </div>
 
   <!-- Show all of the stats for the individual repo -->
-  <div class="col-lg-2 col-md-2 col-sm-2">
+<!--   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= repo.deploy_count %></span>
       <span class="mega-octicon octicon-rocket"></span>
     </div>
-  </div>
+  </div> -->
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= repo.pull_request_count %></span>

--- a/app/views/hubstats/partials/_repo.html.erb
+++ b/app/views/hubstats/partials/_repo.html.erb
@@ -16,12 +16,6 @@
   </div>
 
   <!-- Show all of the stats for the individual repo -->
-<!--   <div class="col-lg-2 col-md-2 col-sm-2">
-    <div class="text-center">
-      <span class="text-large"><%= repo.deploy_count %></span>
-      <span class="mega-octicon octicon-rocket"></span>
-    </div>
-  </div> -->
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= repo.pull_request_count %></span>

--- a/app/views/hubstats/partials/_user.html.erb
+++ b/app/views/hubstats/partials/_user.html.erb
@@ -18,13 +18,15 @@
     </h4>
   </div>
 
+  <div class="col-lg-1 col-md-1 col-sm-1" ></div> <!-- Empty column just to make space -->
+
   <!-- Show the basic stats for this user for this user -->
-  <div class="col-lg-2 col-md-2 col-sm-2">
+<!--   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= user.deploy_count %></span>
       <span class="mega-octicon octicon-rocket"></span>
     </div>
-  </div>
+  </div> -->
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= user.pull_request_count %></span>
@@ -44,7 +46,7 @@
     </div>
   </div>
 
-  <div class="col-lg-1 col-md-1 col-sm-1">
+  <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= user.additions - user.deletions %></span>
     </div>

--- a/app/views/hubstats/partials/_user.html.erb
+++ b/app/views/hubstats/partials/_user.html.erb
@@ -21,12 +21,6 @@
   <div class="col-lg-1 col-md-1 col-sm-1" ></div> <!-- Empty column just to make space -->
 
   <!-- Show the basic stats for this user for this user -->
-<!--   <div class="col-lg-2 col-md-2 col-sm-2">
-    <div class="text-center">
-      <span class="text-large"><%= user.deploy_count %></span>
-      <span class="mega-octicon octicon-rocket"></span>
-    </div>
-  </div> -->
   <div class="col-lg-2 col-md-2 col-sm-2">
     <div class="text-center">
       <span class="text-large"><%= user.pull_request_count %></span>

--- a/app/views/hubstats/repos/show.html.erb
+++ b/app/views/hubstats/repos/show.html.erb
@@ -26,12 +26,12 @@
       <% end %>
     </div>
 
-    <!-- Show all of the deploys in a "condensed" view -->
-    <div class="col col-lg-6">
-      <h3> Deployments </h3>
-      <%= render "hubstats/tables/deploys_condensed" %>
-      <% if @deploy_count > 20 %>
-        <p class="pull-right"><%= link_to "View All", deploys_path(:repos => @repo.id) %></p>
+    <!-- Show all of the active users that contribute to this repo users in a "condensed" view -->
+    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
+      <h3> Active Users </h3>
+      <%= render 'hubstats/tables/users_condensed' %>
+      <% if @active_user_count > 20 %>
+        <p class="pull-right">Hubstats is currently not set up to view all active users for this repository</p>
       <% end %>
     </div>
   </div>

--- a/app/views/hubstats/tables/_qa_signoffs_condensed.html.erb
+++ b/app/views/hubstats/tables/_qa_signoffs_condensed.html.erb
@@ -1,7 +1,7 @@
 <!-- Show the QA Signoffs or say there are no signoffs available -->
 <% if @qa_signoffs.length > 0 %>
-  <div class="qa_signoffs">
-    <%= render partial: 'hubstats/partials/qa-signoffs-condensed', collection: @qa_signoffs, as: :qa_signoff %>
+  <div class="pulls">
+    <%= render partial: 'hubstats/partials/qa-signoff-condensed', collection: @qa_signoffs, as: :qa_signoff %>
   </div>
 <% else %>
   <p> No QA signoff information available</p>

--- a/app/views/hubstats/tables/_repos.html.erb
+++ b/app/views/hubstats/tables/_repos.html.erb
@@ -2,12 +2,13 @@
 <% if @repos.length > 0 %>
   <div class="repos">
     <div class="row single-repo header">
-      <div class="col-lg-2 col-md-2 col-sm-2">
+      <div class="col-lg-3 col-md-3 col-sm-3">
         <a class="header desc" id="name"> Repository Name <span class="octicon"></span> </a>
       </div>
-      <div class="col-lg-2 col-md-2 col-sm-2">
+      <div class="col-lg-1 col-md-1 col-sm-1" ></div> <!-- Empty column just to make space -->
+<!--       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="deploys"> Deployments <span class="octicon"></span> </a>
-      </div>
+      </div> -->
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>

--- a/app/views/hubstats/tables/_repos.html.erb
+++ b/app/views/hubstats/tables/_repos.html.erb
@@ -6,9 +6,6 @@
         <a class="header desc" id="name"> Repository Name <span class="octicon"></span> </a>
       </div>
       <div class="col-lg-1 col-md-1 col-sm-1" ></div> <!-- Empty column just to make space -->
-<!--       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="deploys"> Deployments <span class="octicon"></span> </a>
-      </div> -->
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>

--- a/app/views/hubstats/tables/_users.html.erb
+++ b/app/views/hubstats/tables/_users.html.erb
@@ -2,12 +2,12 @@
 <% if @users.length > 0 %>
   <div class="users">
     <div class="row single-user header">
-      <div class="col-lg-3 col-md-3 col-sm-3">
+      <div class="col-lg-4 col-md-4 col-sm-4">
         <a class="header desc" id="name"> GitHub Username <span class="octicon"></span> </a>
       </div>
-      <div class="col-lg-2 col-md-2 col-sm-2">
+<!--       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="deploys"> Deployments <span class="octicon"></span> </a>
-      </div>
+      </div> -->
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>
@@ -17,7 +17,7 @@
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="signoffs"> QA Signoffs <span class="octicon"></span></a>
       </div>
-      <div class="col-lg-1 col-md-1 col-sm-1">
+      <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="netadditions"> Net Additions <span class="octicon"></span></a>
       </div>
     </div>

--- a/app/views/hubstats/tables/_users.html.erb
+++ b/app/views/hubstats/tables/_users.html.erb
@@ -5,9 +5,6 @@
       <div class="col-lg-4 col-md-4 col-sm-4">
         <a class="header desc" id="name"> GitHub Username <span class="octicon"></span> </a>
       </div>
-<!--       <div class="col-lg-2 col-md-2 col-sm-2">
-        <a class="header desc" id="deploys"> Deployments <span class="octicon"></span> </a>
-      </div> -->
       <div class="col-lg-2 col-md-2 col-sm-2">
         <a class="header desc" id="pulls"> Merged Pull Requests <span class="octicon"></span> </a>
       </div>

--- a/app/views/hubstats/teams/show.html.erb
+++ b/app/views/hubstats/teams/show.html.erb
@@ -30,6 +30,9 @@
     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
       <h3> Active Users </h3>
       <%= render 'hubstats/tables/users_condensed' %>
+      <% if @active_user_count > 20 %>
+        <p class="pull-right">Hubstats is currently not set up to view all active users for this team</p>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/hubstats/users/show.html.erb
+++ b/app/views/hubstats/users/show.html.erb
@@ -36,15 +36,6 @@
       <% end %>
     </div>
 
-    <!-- Show all of this user's deploys in a "condensed" view -->
-    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
-      <h3> Deployments </h3>
-      <%= render 'hubstats/tables/deploys_condensed' %>
-      <% if @deploy_count > 20 %>
-        <p class="pull-right"><%= link_to "View All", deploys_path(:users => @user.id) %></p>
-      <% end %>
-    </div>
-
     <!-- Show all of this user's QA Signoffs in a "condensed" view -->
     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
       <h3> QA Signoffs </h3>

--- a/app/views/hubstats/users/show.html.erb
+++ b/app/views/hubstats/users/show.html.erb
@@ -41,7 +41,7 @@
       <h3> QA Signoffs </h3>
       <%= render 'hubstats/tables/qa_signoffs_condensed' %>
       <% if @qa_signoff_count > 20 %>
-        <p class="pull-right">Hubstats is currently not set up to View All QA signoffs</p>
+        <p class="pull-right">Hubstats is currently not set up to view all QA signoffs</p>
       <% end %>
     </div>
   </div>

--- a/app/views/hubstats/users/show.html.erb
+++ b/app/views/hubstats/users/show.html.erb
@@ -41,7 +41,7 @@
       <h3> QA Signoffs </h3>
       <%= render 'hubstats/tables/qa_signoffs_condensed' %>
       <% if @qa_signoff_count > 20 %>
-        <p class="pull-right">Hubstats is currently not set up to view all QA signoffs</p>
+        <p class="pull-right">Hubstats is currently not set up to view all QA signoffs for this user</p>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
## What
This PR will remove the showing of data for deployments.

To make the new version easier to manage for anyone who is currently using Hubstats to track deployments, I will leave some of the logic, as well as the basic deploy files, such as `app/controllers/hubstats/deploys_controller.rb`, in place. This PR then will serve as a record of what was removed and what was changed in the code, so anyone who still wants/needs pieces of the old versions can add it back into their personal clone of Hubstats. Alternatively, other users can choose not to update their Hubstats gem to the next version.

## Why
The reason SportsEngine is removing this functionality is because we no longer need it. We now use a different deployment monitoring system, one that works a bit better for our use.

Several months ago, we realized the deployment data Hubstats was tracking was showing inaccurate results, and was inconsistent. Webhooks were failing, and SportsEngine decided that we weren't in the mood to debug the errors; we were already working on a new deployment tracking system.

Therefore, at this point in time, it no longer benefits us to show inaccurate tracking data.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Verify on staging that repo/show, user/show, and team/show all don't include deployments, but rather QA signoffs or active users
- [x] Verify on staging that repo/index, user/index, and team/index don't show deployment stats, but rather QA signoffs stats