### PR TITLE
Removing places for Client IDs and Client secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ The following setup is designed to only be used when integrating this plugin int
 Hubstats needs GitHub credentials to access your repositories, these can be setup in one of two ways:
 
 #### GitHub API Tokens
-Add your GitHub API token (called `access_token`) or ClientID and Secret to `octokit.yml`.
+Add your GitHub API token (called `access_token`) to `octokit.yml`.
 
 #### Environment Variables
-Hubstats can also use OAUTH access tokens stored in ENV["GITHUB_API_TOKEN"] or for Application Authentication in ENV["CLIENT_ID"] and ENV["CLIENT_SECRET"], if for some reason you don't want to store them in `octokit.yml`.
+Hubstats can also use OAUTH access tokens stored in ENV["GITHUB_API_TOKEN"] if for some reason you don't want to store them in `octokit.yml`.
 
 ### Configuring Data to be Received from GitHub
 #### Organizations to Follow

--- a/lib/generators/hubstats/octokit.example.yml
+++ b/lib/generators/hubstats/octokit.example.yml
@@ -1,7 +1,5 @@
-github_auth: # Must include either access_token || (client_id && client_secret)
+github_auth: # Must include either access_token
   # access_token: <40 CHARACTER ACCESS TOKEN >
-  # client_id: <CLIENT ID>
-  # client_secret: <CLIENT SECRET>
 
 github_config: # Must include org_name. The repo_list, team_list, and ignore_users_list are optional.
   # org_name: <ORGANIZATION NAME>

--- a/lib/generators/hubstats/octokit.example.yml
+++ b/lib/generators/hubstats/octokit.example.yml
@@ -1,4 +1,4 @@
-github_auth: # Must include either access_token
+github_auth: # Must include access_token
   # access_token: <40 CHARACTER ACCESS TOKEN >
 
 github_config: # Must include org_name. The repo_list, team_list, and ignore_users_list are optional.


### PR DESCRIPTION
Description and Impact
----------------------
We were informed via https://github.com/sportngin/hubstats/issues/117 that Client IDs and secrets don't actually work as authentication. SportsEngine was unaware of this up until now because we authenticate via access tokens.

Deploy Plan
-----------
None.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
None.