### PR TITLE
Ignore git comments that do not have a user_id field

### DIFF
--- a/app/models/hubstats/comment.rb
+++ b/app/models/hubstats/comment.rb
@@ -32,6 +32,11 @@ module Hubstats
     def self.create_or_update(github_comment)
       github_comment = github_comment.to_h.with_indifferent_access if github_comment.respond_to? :to_h
 
+      unless github_comment[:user_id]
+        Rails.logger.warn "Found comment with no user, ignoring. GitHub comment ID: #{github_comment[:id]}"
+        return nil
+      end
+
       user = Hubstats::User.create_or_update(github_comment[:user])
       github_comment[:user_id] = user.id
       

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -70,6 +70,16 @@ module Hubstats
         allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
         expect(ehandler.route(payload, payload[:type]).class).to eq(Hubstats::Comment)
       end
+
+      it 'should successfully creates_or_updates the event even if the user_id is missing' do
+        ehandler = Hubstats::EventsHandler.new()
+        payload = build(:comment_payload_hash, :user => {:login=>"hermina", :id=>0, :role=>"User"},
+                        :comment => {"id"=>194761, "body"=>"Quidem ea minus ut odio optio.",
+                                     "kind"=>"Issue", "repo_id"=>101010,
+                                     "created_at" => Date.today, "updated_at" => Date.today})
+        allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
+        expect(ehandler.route(payload, payload[:type])).to be_nil
+      end
     end
 
     context "TeamEvent" do


### PR DESCRIPTION
Believe it or not, I hit one of these when loading an 8 year old repo that I use.