### PR TITLE
Force a wait limit for every 10 repos

### DIFF
--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -270,7 +270,8 @@ module Hubstats
     # rate_limit - the amount of time to wait to grab data
     #
     # Returns - nothing
-    def self.wait_limit(grab_size, rate_limit)
+    def self.wait_limit(grab_size, rate_limit=nil)
+      rate_limit = client.rate_limit unless rate_limit
       if rate_limit.remaining < grab_size
         puts "Hit Github rate limit, waiting #{Time.at(rate_limit.resets_in).utc.strftime("%H:%M:%S")} to get more"
         sleep(rate_limit.resets_in)

--- a/lib/hubstats/github_api.rb
+++ b/lib/hubstats/github_api.rb
@@ -44,7 +44,7 @@ module Hubstats
       octo = client({:auto_paginate => true})
       octo.paginate(path, options) do |data, last_response|
         last_response.data.each{|v| route(v,kind,repo_name)}.clear
-        wait_limit(1, false, octo.rate_limit)
+        wait_limit(false, 1, octo.rate_limit)
       end.each{|v| route(v,kind,repo_name)}.clear
     end
 
@@ -82,7 +82,7 @@ module Hubstats
             pr = client.pull_request(repo.full_name, pull.number)
             Hubstats::PullRequest.create_or_update(HubHelper.pull_setup(pr))
           end
-          wait_limit(grab_size, false, client.rate_limit)
+          wait_limit(false, grab_size, client.rate_limit)
         end
         puts "All Pull Requests are up to date"
       rescue Faraday::ConnectionFailed
@@ -115,7 +115,7 @@ module Hubstats
             end
           end
         end
-        wait_limit(grab_size, false, client.rate_limit)
+        wait_limit(false, grab_size, client.rate_limit)
         puts "All teams are up to date"
       rescue Faraday::ConnectionFailed
         puts "Connection Timeout, restarting team updating"
@@ -270,8 +270,10 @@ module Hubstats
     # rate_limit - the amount of time to wait to grab data
     #
     # Returns - nothing
-    def self.wait_limit(grab_size, force, rate_limit=nil)
+    def self.wait_limit(force, grab_size=nil, rate_limit=nil)
       rate_limit = client.rate_limit unless rate_limit
+      grab_size = 250 unless grab_size
+
       if force || rate_limit.remaining < grab_size
         puts "We don't want to hit the GitHub wait limit; waiting #{Time.at(rate_limit.resets_in).utc.strftime("%H:%M:%S")} to get more"
         sleep(rate_limit.resets_in)

--- a/lib/tasks/populate_task.rake
+++ b/lib/tasks/populate_task.rake
@@ -25,7 +25,7 @@ namespace :hubstats do
           end
         end
         wait_count = (chunks_count - (index + 1)) * 20
-        Hubstats::GithubAPI.wait_limit(wait_count)
+        Hubstats::GithubAPI.wait_limit(wait_count, true)
       end
 
       puts "Finished with initial updating, grabbing extra info about pull requests"

--- a/lib/tasks/populate_task.rake
+++ b/lib/tasks/populate_task.rake
@@ -15,11 +15,19 @@ namespace :hubstats do
 
     desc "Updates which repos hubstats tracks" 
     task :update_repos => :environment do
-      Hubstats::GithubAPI.get_repos.each do |repo|
-        unless Hubstats::Repo.where(full_name: repo.full_name).first
-          Rake::Task["hubstats:populate:setup_repo"].execute({repo: repo})
+      repos_in_chunks_of_10 = Hubstats::GithubAPI.get_repos.each_slice(10).to_a
+      chunks_count = repos_in_chunks_of_10.count
+
+      repos_in_chunks_of_10.each_with_index do |repo_chunk, index|
+        repo_chunk.each do |repo|
+          unless Hubstats::Repo.where(full_name: repo.full_name).first
+            Rake::Task["hubstats:populate:setup_repo"].execute({repo: repo})
+          end
         end
+        wait_count = (chunks_count - (index + 1)) * 20
+        Hubstats::GithubAPI.wait_limit(wait_count)
       end
+
       puts "Finished with initial updating, grabbing extra info about pull requests"
       Rake::Task["hubstats:populate:update_pulls"].execute
       puts "Finished grabbing info about pull requests, populating teams"

--- a/lib/tasks/populate_task.rake
+++ b/lib/tasks/populate_task.rake
@@ -15,7 +15,7 @@ namespace :hubstats do
 
     desc "Updates which repos hubstats tracks" 
     task :update_repos => :environment do
-      Hubstats::GithubAPI.get_repos.each_with_index do |repo_chunk, index|
+      Hubstats::GithubAPI.get_repos.each_with_index do |repo, index|
         unless Hubstats::Repo.where(full_name: repo.full_name).first
           Rake::Task["hubstats:populate:setup_repo"].execute({repo: repo})
         end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -15,7 +15,7 @@ development:
 test:
   adapter: mysql2
   database: hubstats_test
-  username: <%= ENV['TRAVIS'] ? 'travis' : 'root' %>
+  username: 'root'
   pool: 5
   timeout: 5000
 


### PR DESCRIPTION
What
----------------------
So that we don't hit the GitHub rate limit when adding lots of repositories to Hubstats, force a wait after every 10 repositories.

Why
----------------------
Because when we hit a rate limit for a long time, we have to restart the commands and we get alerted from our systems.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

- [ ] Example scenario

