### PR TITLE
Handle Emojis in Comments.

### DIFF
--- a/db/migrate/20171104172008_handle_emojis_in_comments.rb
+++ b/db/migrate/20171104172008_handle_emojis_in_comments.rb
@@ -1,6 +1,10 @@
 class HandleEmojisInComments < ActiveRecord::Migration
   def change
-      execute("ALTER TABLE hubstats_comments MODIFY body TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;")
+
+      # Set the body column to use 4-byte characters so that 4-byte UTF-8 chars, such as emojis, can be stored.
+      change_column :hubstats_comments, :body, "TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
+
+      # Set the connection to use a 4-byte encoding as well.
       execute("set names 'utf8mb4';")
   end
 end

--- a/db/migrate/20171104172008_handle_emojis_in_comments.rb
+++ b/db/migrate/20171104172008_handle_emojis_in_comments.rb
@@ -1,0 +1,6 @@
+class HandleEmojisInComments < ActiveRecord::Migration
+  def change
+      execute("ALTER TABLE hubstats_comments MODIFY body TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;")
+      execute("set names 'utf8mb4';")
+  end
+end


### PR DESCRIPTION
Fixes #99 by using `uft8mb4` characters to store the body of comments. 
By default, mysql allocates 3 bytes per character, but emojis require the UTF standard of 4 bytes, so we need to change the table schema to accommodate them.

This also changes the mysql connection to use utf8mb4, which is harmless as far as I know.

Tested by observing that the `setup` task succeeds with this change and not without, and by building the `dummy` project and poking around the UI.

Future work might include changing text/varchar column to use `uft8mb4`, as GitHub emojis can be used in a lot of different places, not just the body of comments.