### PR TITLE
Show 50 items in detailed show pages

### DIFF
--- a/app/controllers/hubstats/deploys_controller.rb
+++ b/app/controllers/hubstats/deploys_controller.rb
@@ -24,7 +24,7 @@ module Hubstats
     def show
       @deploy = Hubstats::Deploy.includes(:repo, :pull_requests).find(params[:id])
       repo = @deploy.repo
-      @pull_requests = @deploy.pull_requests.limit(20)
+      @pull_requests = @deploy.pull_requests.limit(50)
       @pull_request_count = @pull_requests.length
       @stats_row_one = {
         pull_count: @pull_request_count,

--- a/app/controllers/hubstats/pull_requests_controller.rb
+++ b/app/controllers/hubstats/pull_requests_controller.rb
@@ -30,7 +30,7 @@ module Hubstats
     def show
       @repo = Hubstats::Repo.where(name: params[:repo]).first
       @pull_request = Hubstats::PullRequest.belonging_to_repo(@repo.id).where(id: params[:id]).first
-      @comments = Hubstats::Comment.belonging_to_pull_request(params[:id]).created_in_date_range(@start_date, @end_date).limit(20)
+      @comments = Hubstats::Comment.belonging_to_pull_request(params[:id]).created_in_date_range(@start_date, @end_date).limit(50)
       comment_count = Hubstats::Comment.belonging_to_pull_request(params[:id]).created_in_date_range(@start_date, @end_date).count(:all)
       @deploys = Hubstats::Deploy.where(id: @pull_request.deploy_id).order("deployed_at DESC")
       @stats_row_one = {

--- a/app/controllers/hubstats/repos_controller.rb
+++ b/app/controllers/hubstats/repos_controller.rb
@@ -31,12 +31,12 @@ module Hubstats
     # Returns - the specific repository data
     def show
       @repo = Hubstats::Repo.where(name: params[:repo]).first
-      @pull_requests = Hubstats::PullRequest.belonging_to_repo(@repo.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(20)
+      @pull_requests = Hubstats::PullRequest.belonging_to_repo(@repo.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(50)
       @pull_count = Hubstats::PullRequest.belonging_to_repo(@repo.id).merged_in_date_range(@start_date, @end_date).count(:all)
-      @deploys = Hubstats::Deploy.belonging_to_repo(@repo.id).deployed_in_date_range(@start_date, @end_date).order("deployed_at DESC").limit(20)
+      @deploys = Hubstats::Deploy.belonging_to_repo(@repo.id).deployed_in_date_range(@start_date, @end_date).order("deployed_at DESC").limit(50)
       @deploy_count = Hubstats::Deploy.belonging_to_repo(@repo.id).deployed_in_date_range(@start_date, @end_date).count(:all)
       @comment_count = Hubstats::Comment.belonging_to_repo(@repo.id).created_in_date_range(@start_date, @end_date).count(:all)
-      @users = Hubstats::User.with_pulls_or_comments_or_deploys(@start_date, @end_date, @repo.id).only_active.order("login ASC").limit(20)
+      @users = Hubstats::User.with_pulls_or_comments_or_deploys(@start_date, @end_date, @repo.id).only_active.order("login ASC").limit(50)
       @active_user_count = Hubstats::User.with_pulls_or_comments_or_deploys(@start_date, @end_date, @repo.id).only_active.length
       @qa_signoff_count = Hubstats::QaSignoff.belonging_to_repo(@repo.id).signed_within_date_range(@start_date, @end_date).count(:all)
       @net_additions = Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_repo(@repo.id).sum(:additions).to_i -

--- a/app/controllers/hubstats/teams_controller.rb
+++ b/app/controllers/hubstats/teams_controller.rb
@@ -31,7 +31,7 @@ module Hubstats
     # Returns - the data of the specific team
     def show
       @team = Hubstats::Team.where(id: params[:id]).first
-      @pull_requests = Hubstats::PullRequest.belonging_to_team(@team.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(20)
+      @pull_requests = Hubstats::PullRequest.belonging_to_team(@team.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(50)
       @pull_count = Hubstats::PullRequest.belonging_to_team(@team.id).merged_in_date_range(@start_date, @end_date).count(:all)
       @users = @team.users.where.not(login: Hubstats.config.github_config["ignore_users_list"] || []).order("login ASC").distinct
       @active_user_count = @users.length

--- a/app/controllers/hubstats/users_controller.rb
+++ b/app/controllers/hubstats/users_controller.rb
@@ -32,11 +32,11 @@ module Hubstats
     # Returns - the data of the specific user
     def show
       @user = Hubstats::User.where(login: params[:id]).first
-      @pull_requests = Hubstats::PullRequest.belonging_to_user(@user.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(20)
+      @pull_requests = Hubstats::PullRequest.belonging_to_user(@user.id).merged_in_date_range(@start_date, @end_date).order("updated_at DESC").limit(50)
       @pull_count = Hubstats::PullRequest.belonging_to_user(@user.id).merged_in_date_range(@start_date, @end_date).count(:all)
-      @deploys = Hubstats::Deploy.belonging_to_user(@user.id).deployed_in_date_range(@start_date, @end_date).order("deployed_at DESC").limit(20)
+      @deploys = Hubstats::Deploy.belonging_to_user(@user.id).deployed_in_date_range(@start_date, @end_date).order("deployed_at DESC").limit(50)
       @deploy_count = Hubstats::Deploy.belonging_to_user(@user.id).deployed_in_date_range(@start_date, @end_date).count(:all)
-      @qa_signoffs = Hubstats::QaSignoff.belonging_to_user(@user.id).signed_within_date_range(@start_date, @end_date).order("signed_at DESC").limit(20)
+      @qa_signoffs = Hubstats::QaSignoff.belonging_to_user(@user.id).signed_within_date_range(@start_date, @end_date).order("signed_at DESC").limit(50)
       @qa_signoff_count = Hubstats::QaSignoff.belonging_to_user(@user.id).signed_within_date_range(@start_date, @end_date).count(:all)
       @comment_count = Hubstats::Comment.belonging_to_user(@user.id).created_in_date_range(@start_date, @end_date).count(:all)
       @net_additions = Hubstats::PullRequest.merged_in_date_range(@start_date, @end_date).belonging_to_user(@user.id).sum(:additions).to_i -

--- a/app/views/hubstats/deploys/show.html.erb
+++ b/app/views/hubstats/deploys/show.html.erb
@@ -21,7 +21,7 @@
     <div class="row">
       <h4> Merged Pull Requests </h4>
       <%= render 'hubstats/tables/pulls_condensed' %>
-      <% if @pull_request_count > 20 %>
+      <% if @pull_request_count > 50 %>
         <p class="pull-right"><%= link_to "View All", pulls_path(:deploys => @deploy.id) %></p>
       <% end %>
     </div>

--- a/app/views/hubstats/repos/show.html.erb
+++ b/app/views/hubstats/repos/show.html.erb
@@ -21,7 +21,7 @@
     <div class="col col-lg-6">
       <h3> Merged Pull Requests</h3>
       <%= render 'hubstats/tables/pulls_condensed'%>
-      <% if @pull_count > 20 %>
+      <% if @pull_count > 50 %>
         <p class="pull-right"><%= link_to "View All", pulls_path(:repos => @repo.id) %></p>
       <% end %>
     </div>
@@ -30,7 +30,7 @@
     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
       <h3> Active Users </h3>
       <%= render 'hubstats/tables/users_condensed' %>
-      <% if @active_user_count > 20 %>
+      <% if @active_user_count > 50 %>
         <p class="pull-right">Hubstats is currently not set up to view all active users for this repository</p>
       <% end %>
     </div>

--- a/app/views/hubstats/teams/show.html.erb
+++ b/app/views/hubstats/teams/show.html.erb
@@ -21,7 +21,7 @@
     <div class="col-lg-6 col-md-5 col-sm-5 col-xs-5">
       <h3> Merged Pull Requests</h3> 
       <%= render 'hubstats/tables/pulls_condensed' %>
-      <% if @pull_count > 20 %>
+      <% if @pull_count > 50 %>
         <p class="pull-right"><%= link_to "View All", pulls_path(:teams => @team.id) %></p>
       <% end %>
     </div>
@@ -30,7 +30,7 @@
     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
       <h3> Active Users </h3>
       <%= render 'hubstats/tables/users_condensed' %>
-      <% if @active_user_count > 20 %>
+      <% if @active_user_count > 50 %>
         <p class="pull-right">Hubstats is currently not set up to view all active users for this team</p>
       <% end %>
     </div>

--- a/app/views/hubstats/users/show.html.erb
+++ b/app/views/hubstats/users/show.html.erb
@@ -31,7 +31,7 @@
     <div class="col-lg-6 col-md-5 col-sm-5 col-xs-5">
       <h3> Merged Pull Requests</h3> 
       <%= render 'hubstats/tables/pulls_condensed' %>
-      <% if @pull_count > 20 %>
+      <% if @pull_count > 50 %>
         <p class="pull-right"><%= link_to "View All", pulls_path(:users => @user.id) %></p>
       <% end %>
     </div>


### PR DESCRIPTION
What
----------------------
Show up to 50 detailed items instead of 20. "Detailed item" includes QA signoffs, pull requests, comments, etc.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Verify that we can see more than 20 items