### PR TITLE
Fix bug that results in comments never being saved

### DIFF
--- a/app/models/hubstats/comment.rb
+++ b/app/models/hubstats/comment.rb
@@ -33,7 +33,6 @@ module Hubstats
       github_comment = github_comment.to_h.with_indifferent_access if github_comment.respond_to? :to_h
 
       unless github_comment[:user]
-        puts "github_comment: #{github_comment}"
         Rails.logger.warn "Found comment with no user, ignoring. GitHub comment ID: #{github_comment[:id]}"
         return nil
       end

--- a/app/models/hubstats/comment.rb
+++ b/app/models/hubstats/comment.rb
@@ -32,7 +32,7 @@ module Hubstats
     def self.create_or_update(github_comment)
       github_comment = github_comment.to_h.with_indifferent_access if github_comment.respond_to? :to_h
 
-      unless github_comment[:user_id]
+      unless github_comment[:user]
         Rails.logger.warn "Found comment with no user, ignoring. GitHub comment ID: #{github_comment[:id]}"
         return nil
       end

--- a/app/models/hubstats/comment.rb
+++ b/app/models/hubstats/comment.rb
@@ -33,6 +33,7 @@ module Hubstats
       github_comment = github_comment.to_h.with_indifferent_access if github_comment.respond_to? :to_h
 
       unless github_comment[:user]
+        puts "github_comment: #{github_comment}"
         Rails.logger.warn "Found comment with no user, ignoring. GitHub comment ID: #{github_comment[:id]}"
         return nil
       end

--- a/hubstats.gemspec
+++ b/hubstats.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z`.split("\x0")
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
 
-  s.add_dependency "rails", "~> 4.2"
+  s.add_dependency "rails", "~> 4.2.10"
   s.add_dependency "octokit", "~> 4.2"
   s.add_dependency "will_paginate-bootstrap", "~> 1.0"
   s.add_dependency "select2-rails", "~> 3.0"

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -68,7 +68,9 @@ module Hubstats
                                                             "kind"=>"Issue", "user_id"=>0, "repo_id"=>101010,
                                                             "created_at" => Date.today, "updated_at" => Date.today})
         allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
-        expect(ehandler.route(payload, payload[:type]).class).to eq(Hubstats::Comment)
+        item = ehandler.route(payload, payload[:type])
+        puts "item: #{item}"
+        expect(item.class).to eq(Hubstats::Comment)
       end
 
       it 'should successfully creates_or_updates the event even if the user_id is missing' do

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -63,10 +63,15 @@ module Hubstats
 
       it 'should successfully creates_or_updates the event' do
         ehandler = Hubstats::EventsHandler.new()
-        payload = build(:comment_payload_hash, :user => {:login=>"hermina", :id=>0, :role=>"User"},
-                                               :comment => {"id"=>194761, "body"=>"Quidem ea minus ut odio optio.",
-                                                            "kind"=>"Issue", "user_id"=>0, "repo_id"=>101010,
-                                                            "created_at" => Date.today, "updated_at" => Date.today})
+        payload = build(:comment_payload_hash,
+          :user => {:login=>"hermina", :id=>0, :role=>"User"},
+          :comment => {
+            "id"=>194761, 
+            "body"=>"Quidem ea minus ut odio optio.",
+            "kind"=>"Issue", "user"=>{},
+            "created_at" => Date.today, "updated_at" => Date.today
+          }
+        )
         allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
         item = ehandler.route(payload, payload[:type])
         puts "item: #{item}"
@@ -75,11 +80,15 @@ module Hubstats
 
       it 'should successfully creates_or_updates the event even if the user_id is missing' do
         ehandler = Hubstats::EventsHandler.new()
-        payload = build(:comment_payload_hash, :user => {:login=>"hermina", :id=>0, :role=>"User"},
-                        :comment => {"id"=>194761, "body"=>"Quidem ea minus ut odio optio.",
-                                     "kind"=>"Issue", "repo_id"=>101010,
-                                     "created_at" => Date.today, "updated_at" => Date.today})
-        allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
+        payload = build(:comment_payload_hash,
+          :user => {:login=>"hermina", :id=>0, :role=>"User"},
+          :comment => {
+            "id"=>194761, 
+            "body"=>"Quidem ea minus ut odio optio.",
+            "kind"=>"Issue", "user"=>{},
+            "created_at" => Date.today, "updated_at" => Date.today
+          }
+        )        allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
         expect(ehandler.route(payload, payload[:type])).to be_nil
       end
     end

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -68,25 +68,27 @@ module Hubstats
           :comment => {
             "id"=>194761, 
             "body"=>"Quidem ea minus ut odio optio.",
-            "kind"=>"Issue", "user"=>{},
-            "created_at" => Date.today, "updated_at" => Date.today
+            "kind"=>"Issue",
+            "user"=>{},
+            "created_at" => Date.today,
+            "updated_at" => Date.today
           }
         )
         allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
-        item = ehandler.route(payload, payload[:type])
-        puts "item: #{item}"
-        expect(item.class).to eq(Hubstats::Comment)
+        expect(ehandler.route(payload, payload[:type]).class).to eq(Hubstats::Comment)
       end
 
-      it 'should successfully creates_or_updates the event even if the user_id is missing' do
+      it 'should successfully creates_or_updates the event even if the user is missing' do
         ehandler = Hubstats::EventsHandler.new()
         payload = build(:comment_payload_hash,
           :user => {:login=>"hermina", :id=>0, :role=>"User"},
           :comment => {
             "id"=>194761, 
             "body"=>"Quidem ea minus ut odio optio.",
-            "kind"=>"Issue", "user"=>{},
-            "created_at" => Date.today, "updated_at" => Date.today
+            "kind"=>"Issue", 
+            "user"=>nil,
+            "created_at" => Date.today, 
+            "updated_at" => Date.today
           }
         )
         allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)

--- a/spec/lib/hubstats/events_handler_spec.rb
+++ b/spec/lib/hubstats/events_handler_spec.rb
@@ -88,7 +88,8 @@ module Hubstats
             "kind"=>"Issue", "user"=>{},
             "created_at" => Date.today, "updated_at" => Date.today
           }
-        )        allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
+        )
+        allow(Hubstats::User).to receive_message_chain(:create_or_update).and_return(user)
         expect(ehandler.route(payload, payload[:type])).to be_nil
       end
     end


### PR DESCRIPTION
What
----------------------
`github_comment[:user_id]` is not a thing on line 35 of that file. It is defined on line 42. Therefore, we must call what we know, which is `github_comment[:user]`. Also adjust the tests so the stubbed payload matches more what payloads actually look like. Lastly, upgrade version of Rails so that Ruby can be compatible with Rails again.

Why
----------------------
Because that was always evaluating as `nil`, we were never saving comments.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
Test it out! Make sure that incoming comments save again.