### PR TITLE
Resolve gem vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: ruby
 cache: bundler
 install:
   - gem install bundler -v 1.17.3
-  - bundle install --without development --deployment --jobs=3 --retry=3
+  - bundle install --jobs=3 --retry=3
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 dist: trusty
 language: ruby
 cache: bundler
+install:
+  - gem install bundler -v 1.17.3
+  - bundle install --without development --deployment --jobs=3 --retry=3
 
 branches:
   only:
@@ -16,4 +19,3 @@ before_script:
   - bundle exec rake app:db:create
   - bundle exec rake app:db:migrate
   - bundle exec rake app:db:test:prepare
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,17 @@ language: ruby
 cache: bundler
 install:
   - gem install bundler -v 1.17.3
-  - bundle install --jobs=3 --retry=3
+  - bundle _1.17.3_ install --jobs=3 --retry=3
 
 branches:
   only:
     - master
+
 rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.3.3
 
 script: bundle exec rspec
 before_script:

--- a/hubstats.gemspec
+++ b/hubstats.gemspec
@@ -17,11 +17,13 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
 
   s.add_dependency "rails", "~> 4.2.10"
-  s.add_dependency "rake", "= 12.3.2"
+  s.add_dependency "rake", ">= 12.3.3"
   s.add_dependency "octokit", "~> 4.2"
   s.add_dependency "will_paginate-bootstrap", "~> 1.0"
   s.add_dependency "select2-rails", "~> 3.0"
   s.add_dependency "sass-rails"
+  s.add_dependency "railties", "~> 4.2.11.1"
+  s.add_dependency "jquery-rails", "= 4.3.3"
   s.add_dependency "bootstrap-datepicker-rails", "~> 1.5"
 
   s.add_development_dependency "mysql2",'~> 0.3.2'


### PR DESCRIPTION
What
----------------------
Resolve the gem vulnerabilities in the [Security tab](https://github.com/sportngin/hubstats/network/alerts).

Why
----------------------
Because we want our applications to have as few security vulnerabilities as possible.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Use this branch of Hubstats to update the gem vulnerabilities (if any) in our home application
- [x] Verify that the home application continues to work successfully