### PR TITLE
IS-12226 Update octokit

### DIFF
--- a/hubstats.gemspec
+++ b/hubstats.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 4.2.10"
   s.add_dependency "rake", ">= 12.3.3"
-  s.add_dependency "octokit", "~> 4.2"
+  s.add_dependency "octokit", "~> 4.18"
   s.add_dependency "will_paginate-bootstrap", "~> 1.0"
   s.add_dependency "select2-rails", "~> 3.0"
   s.add_dependency "sass-rails"


### PR DESCRIPTION
What
----------------------
Enforce Hubstats to use octokit version 4.18.0 or higher.

Why
----------------------
Because upcoming deprecations will make earlier versions of octokit fail: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Deploy Plan
-----------
Run the following:
```
op accept-pull 143
soyuz deploy # choose a patch release
```

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Test out that the newer version of octokit continues to work in your applications